### PR TITLE
Looter v0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ It replaces manual loot tracking with a fast, visual workflow that lets GMs roll
 
 ## Requirements
 
-- **Foundry VTT**: v13.351  
-- **System**: D&D 5e v5.2.5  
+- **Foundry VTT**: v14
+- **System**: D&D 5e v5.3.0
 
 ---
 
@@ -82,9 +82,10 @@ It replaces manual loot tracking with a fast, visual workflow that lets GMs roll
 
 ### Manual Install
 1. Download the latest release `.zip`
-2. Extract into: FoundryVTT/Data/modules/looter
-3. Restart Foundry
-4. Enable **Looter** in your world
+2. Extract into: `FoundryVTT/Data/modules/looter`
+3. Make sure the module folder name is exactly `looter`
+4. Restart Foundry
+5. Enable **Looter** in your world
 
 ---
 

--- a/module.json
+++ b/module.json
@@ -2,15 +2,15 @@
   "id": "looter",
   "title": "Looter",
   "description": "Post-combat rewards distribution module for the D&D 5e (2024) system of Foundry VTT.",
-  "version": "0.3.17",
+  "version": "0.4.1",
   "authors": [
     {
       "name": "GunpowderLullaby"
     }
   ],
   "compatibility": {
-    "minimum": "13",
-    "verified": "13.351"
+    "minimum": "14",
+    "verified": "14.359"
   },
   "relationships": {
     "systems": [
@@ -18,8 +18,8 @@
         "id": "dnd5e",
         "type": "system",
         "compatibility": {
-          "minimum": "5.2.5",
-          "verified": "5.2.5"
+          "minimum": "5.3.0",
+          "verified": "5.3.0"
         }
       }
     ]
@@ -39,6 +39,6 @@
   ],
   "url": "https://github.com/GunpowderLullaby/Looter",
   "manifest": "https://raw.githubusercontent.com/GunpowderLullaby/Looter/main/module.json",
-  "download": "https://github.com/GunpowderLullaby/Looter/releases/download/v0.3.17/looter.zip"
+  "download": ""
 }
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,4 +1,13 @@
 const LOOTER_ID = "looter";
+// Resolve the live install folder from the loaded script so template and module lookups
+// still work when the on-disk folder casing does not match the manifest id.
+const MODULE_ROOT_URL = new URL("../", import.meta.url);
+const MODULE_FOLDER = decodeURIComponent(MODULE_ROOT_URL.pathname)
+  .split("/")
+  .filter(Boolean)
+  .at(-1) || LOOTER_ID;
+const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
+let SETTINGS_NAMESPACE = LOOTER_ID;
 const SNAPSHOTS = new Map();
 const PENDING_OPENS = new Map();
 
@@ -25,8 +34,176 @@ function log(...args) {
   console.log(`${LOOTER_ID} |`, ...args);
 }
 
+function moduleAssetPath(relativePath) {
+  return new URL(String(relativePath ?? "").replace(/^\.?\//, ""), MODULE_ROOT_URL).pathname;
+}
+
+function getLooterModule() {
+  const direct = game.modules.get(LOOTER_ID);
+  if (direct) return direct;
+
+  const fallback = game.modules.get(MODULE_FOLDER)
+    ?? Array.from(game.modules.values()).find(pkg => {
+      const id = String(pkg?.id ?? "").toLowerCase();
+      return id === LOOTER_ID || id === MODULE_FOLDER.toLowerCase();
+    })
+    ?? null;
+
+  if (fallback) {
+    console.warn(
+      `${LOOTER_ID} | Resolved this module using install folder "${MODULE_FOLDER}". ` +
+      `Rename the module folder to "${LOOTER_ID}" to match module.json and avoid V14 package lookup issues.`
+    );
+  }
+
+  return fallback;
+}
+
+const LOOTER_SETTING_CONFIGS = {
+  monsterTable: {
+    name: "Monster Table",
+    hint: "Stored monster rewards lookup table.",
+    scope: "world",
+    config: false,
+    type: Object,
+    default: []
+  },
+  treasureProfiles: {
+    name: "Treasure Profiles",
+    hint: "Currency formulas and linked item tables for each treasure type and CR tier.",
+    scope: "world",
+    config: false,
+    type: Object,
+    default: []
+  },
+  useXp: {
+    name: "Award XP",
+    hint: "Turn this off for milestone campaigns.",
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: true
+  },
+  theme: {
+    name: "Window Theme",
+    hint: "Color theme for Looter windows.",
+    scope: "client",
+    config: true,
+    type: String,
+    choices: THEME_CHOICES,
+    default: "violet"
+  }
+};
+
+function getSettingsNamespace() {
+  return SETTINGS_NAMESPACE;
+}
+
+function registerLooterSettings(namespace, { includeMenus = false, forceHidden = false } = {}) {
+  for (const [key, config] of Object.entries(LOOTER_SETTING_CONFIGS)) {
+    game.settings.register(namespace, key, {
+      ...config,
+      config: forceHidden ? false : config.config
+    });
+  }
+
+  if (!includeMenus) return;
+
+  game.settings.registerMenu(namespace, "monsterTableMenu", {
+    name: "Open Monster Registry",
+    label: "Monster Registry",
+    hint: "Open the Looter monster registry.",
+    icon: "fas fa-dragon",
+    type: LooterMonsterTableApp,
+    restricted: true
+  });
+
+  game.settings.registerMenu(namespace, "treasureProfilesMenu", {
+    name: "Open Treasure Profiles",
+    label: "Treasure Profiles",
+    hint: "Open the Looter treasure profiles manager.",
+    icon: "fas fa-coins",
+    type: LooterTreasureProfilesApp,
+    restricted: true
+  });
+}
+
+function settingValueEquals(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+async function migrateLegacySettingsNamespace(fromNamespace, toNamespace) {
+  if (!fromNamespace || !toNamespace || fromNamespace === toNamespace) return;
+
+  for (const [key, config] of Object.entries(LOOTER_SETTING_CONFIGS)) {
+    const legacyValue = game.settings.get(fromNamespace, key);
+    const currentValue = game.settings.get(toNamespace, key);
+    if (settingValueEquals(legacyValue, config.default)) continue;
+    if (!settingValueEquals(currentValue, config.default)) continue;
+    await game.settings.set(toNamespace, key, legacyValue);
+  }
+}
+
+async function syncSettingsNamespace(sourceNamespace, targetNamespace) {
+  if (!sourceNamespace || !targetNamespace || sourceNamespace === targetNamespace) return;
+
+  for (const key of Object.keys(LOOTER_SETTING_CONFIGS)) {
+    const sourceValue = game.settings.get(sourceNamespace, key);
+    const targetValue = game.settings.get(targetNamespace, key);
+    if (settingValueEquals(sourceValue, targetValue)) continue;
+    await game.settings.set(targetNamespace, key, sourceValue);
+  }
+}
+
+async function normalizeStructuredSettings(namespace) {
+  if (!namespace) return;
+
+  for (const key of ["monsterTable", "treasureProfiles"]) {
+    const stored = game.settings.get(namespace, key);
+    const normalized = normalizeSettingArray(stored);
+    if (settingValueEquals(stored, normalized)) continue;
+    await game.settings.set(namespace, key, normalized);
+  }
+}
+
 function clone(data) {
   return foundry.utils.deepClone(data);
+}
+
+function normalizeSettingArray(value) {
+  let current = clone(value ?? []);
+
+  while (Array.isArray(current) && current.length === 1 && Array.isArray(current[0])) {
+    current = current[0];
+  }
+
+  if (Array.isArray(current)) return current;
+
+  if (current && typeof current === "object") {
+    const numericKeys = Object.keys(current)
+      .filter(key => /^\d+$/.test(key))
+      .sort((a, b) => Number(a) - Number(b));
+    if (numericKeys.length) return numericKeys.map(key => current[key]);
+  }
+
+  return [];
+}
+
+function getEventTargetElement(event) {
+  const target = event?.target;
+  if (target && typeof target.closest === "function") return target;
+  return target?.parentElement ?? null;
+}
+
+function normalizeMonsterRow(row = {}) {
+  return {
+    name: String(row?.name ?? "").trim(),
+    cr: clampNumber(row?.cr, 0),
+    xp: clampNumber(row?.xp, 0),
+    treasureTypes: Array.isArray(row?.treasureTypes)
+      ? row.treasureTypes.map(titleCase).filter(Boolean)
+      : treasureTypesFromString(row?.treasureTypes ?? "")
+  };
 }
 
 function normalizeName(name) {
@@ -69,12 +246,18 @@ function sortMonsterRows(rows, sort = {}) {
   const direction = sort?.direction === "desc" ? "desc" : "asc";
   const factor = direction === "desc" ? -1 : 1;
   return [...rows].sort((a, b) => {
+    const aName = String(a?.name ?? "").trim();
+    const bName = String(b?.name ?? "").trim();
+    const aBlank = !aName;
+    const bBlank = !bName;
+    if (aBlank !== bBlank) return aBlank ? 1 : -1;
+
     if (field === "cr") {
       const diff = clampNumber(a?.cr, 0) - clampNumber(b?.cr, 0);
       if (diff !== 0) return diff * factor;
-      return String(a?.name ?? "").localeCompare(String(b?.name ?? "")) * factor;
+      return aName.localeCompare(bName, undefined, { sensitivity: "base" }) * factor;
     }
-    const diff = String(a?.name ?? "").localeCompare(String(b?.name ?? ""), undefined, { sensitivity: "base" });
+    const diff = aName.localeCompare(bName, undefined, { sensitivity: "base" });
     if (diff !== 0) return diff * factor;
     return (clampNumber(a?.cr, 0) - clampNumber(b?.cr, 0)) * factor;
   });
@@ -102,27 +285,27 @@ function tableName(type, tier) {
 }
 
 function getTheme() {
-  return game.settings.get(LOOTER_ID, "theme") || "violet";
+  return game.settings.get(getSettingsNamespace(), "theme") || "violet";
 }
 
 function getUseXp() {
-  return game.settings.get(LOOTER_ID, "useXp") !== false;
+  return game.settings.get(getSettingsNamespace(), "useXp") !== false;
 }
 
 function getMonsterTable() {
-  return clone(game.settings.get(LOOTER_ID, "monsterTable") ?? []);
+  return normalizeSettingArray(game.settings.get(getSettingsNamespace(), "monsterTable"));
 }
 
 async function setMonsterTable(rows) {
-  await game.settings.set(LOOTER_ID, "monsterTable", rows);
+  await game.settings.set(getSettingsNamespace(), "monsterTable", normalizeSettingArray(rows));
 }
 
 function getTreasureProfiles() {
-  return clone(game.settings.get(LOOTER_ID, "treasureProfiles") ?? []);
+  return normalizeSettingArray(game.settings.get(getSettingsNamespace(), "treasureProfiles"));
 }
 
 async function setTreasureProfiles(rows) {
-  await game.settings.set(LOOTER_ID, "treasureProfiles", rows);
+  await game.settings.set(getSettingsNamespace(), "treasureProfiles", normalizeSettingArray(rows));
 }
 
 function defaultCurrencyBlock() {
@@ -563,13 +746,20 @@ async function resolveDroppedActor(event) {
   if (!data) return null;
 
   try {
-    if (typeof data.uuid === "string" && data.uuid) {
-      const doc = await fromUuid(data.uuid);
+    if (typeof Actor?.fromDropData === "function") {
+      const actor = await Actor.fromDropData(data);
+      if (actor?.documentName === "Actor") return actor;
+    }
+
+    for (const uuid of getDroppedDocumentUuids(data, "Actor")) {
+      const doc = await fromUuid(uuid);
       if (doc?.documentName === "Actor") return doc;
     }
 
-    if (data.type === "Actor" && data.id) {
-      return game.actors.get(data.id) ?? null;
+    const type = String(data.type ?? data.documentName ?? data.documentType ?? "").trim();
+    const id = String(data.id ?? data._id ?? data.documentId ?? data.entryId ?? "").trim();
+    if ((type === "Actor" || !type) && id) {
+      return game.actors.get(id) ?? null;
     }
   } catch (err) {
     console.warn(`${LOOTER_ID} | Failed to resolve dropped actor`, err, data);
@@ -579,13 +769,68 @@ async function resolveDroppedActor(event) {
 }
 
 function getDragEventData(event) {
-  const textEditor = foundry.applications?.ux?.TextEditor?.implementation;
-  if (typeof textEditor?.getDragEventData !== "function") return null;
-  try {
-    return textEditor.getDragEventData(event);
-  } catch (_err) {
-    return null;
+  const dragEvent = event?.originalEvent ?? event;
+  const textEditor = foundry.applications?.ux?.TextEditor?.implementation
+    ?? foundry.applications?.ux?.TextEditor
+    ?? globalThis.TextEditor;
+
+  if (typeof textEditor?.getDragEventData === "function") {
+    try {
+      const data = textEditor.getDragEventData(dragEvent);
+      const hasPayload = data
+        && (typeof data !== "object"
+          || Array.isArray(data)
+          || Object.keys(data).length > 0);
+      if (hasPayload) return data;
+    } catch (_err) {}
   }
+
+  const dataTransfer = dragEvent?.dataTransfer;
+  if (!dataTransfer) return null;
+
+  for (const mimeType of ["application/json", "text/plain", "text"]) {
+    const raw = String(dataTransfer.getData(mimeType) ?? "").trim();
+    if (!raw) continue;
+
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object") return parsed;
+    } catch (_err) {}
+
+    if (/@UUID\[([^\]]+)\]/.test(raw)) return { uuid: raw.match(/@UUID\[([^\]]+)\]/)?.[1] ?? "" };
+    if (/^(Actor|RollTable)\.[A-Za-z0-9]+$/.test(raw) || /^Compendium\.[^.]+\.[^.]+\.[^.]+\.[A-Za-z0-9]+$/.test(raw)) {
+      return { uuid: raw };
+    }
+  }
+
+  return null;
+}
+
+function getDragDropControllerClass() {
+  return CONFIG?.ux?.DragDrop
+    ?? foundry.applications?.ux?.DragDrop
+    ?? globalThis.DragDrop
+    ?? null;
+}
+
+function getDroppedDocumentUuids(data, documentName) {
+  const uuids = new Set();
+  const expected = String(documentName ?? "").trim();
+  const type = String(data?.type ?? data?.documentName ?? data?.documentType ?? "").trim();
+  const id = String(data?.id ?? data?._id ?? data?.documentId ?? data?.entryId ?? "").trim();
+  let pack = String(data?.pack ?? data?.packName ?? data?.collection ?? data?.compendium ?? "").trim();
+  if (pack.startsWith("Compendium.")) pack = pack.slice("Compendium.".length);
+
+  const uuid = String(data?.uuid ?? data?.documentUuid ?? "").trim();
+  if (uuid) uuids.add(uuid);
+
+  if (pack && id) {
+    if (expected) uuids.add(`Compendium.${pack}.${expected}.${id}`);
+    if (type) uuids.add(`Compendium.${pack}.${type}.${id}`);
+  }
+
+  if (id && expected) uuids.add(`${expected}.${id}`);
+  return [...uuids].filter(Boolean);
 }
 
 async function resolveDroppedRollTable(event) {
@@ -595,15 +840,16 @@ async function resolveDroppedRollTable(event) {
   if (!data) return null;
 
   try {
-    if (typeof data.uuid === "string" && data.uuid) {
-      const doc = await fromUuid(data.uuid);
+    for (const uuid of getDroppedDocumentUuids(data, "RollTable")) {
+      const doc = await fromUuid(uuid);
       if (doc?.documentName === "RollTable") {
         const reference = getRollTableReference(doc);
         return { table: doc, reference };
       }
     }
 
-    const isRollTable = data.type === "RollTable" || data.documentName === "RollTable";
+    const type = String(data.type ?? data.documentName ?? data.documentType ?? "").trim();
+    const isRollTable = type === "RollTable";
     if (!isRollTable) return null;
 
     const id = String(data.id ?? data._id ?? data.documentId ?? data.entryId ?? "").trim();
@@ -834,37 +1080,143 @@ function stackEnemiesForDisplay(enemies = []) {
   }));
 }
 
-class LooterMonsterTableApp extends FormApplication {
+class LooterApplicationV2 extends HandlebarsApplicationMixin(ApplicationV2) {
+  static get DEFAULT_OPTIONS() {
+    return foundry.utils.mergeObject(super.DEFAULT_OPTIONS, {
+      classes: ["looter-app"],
+      window: {
+        frame: true,
+        positioned: true,
+        resizable: true
+      }
+    }, { inplace: false });
+  }
+
+  get bodyElement() {
+    return (this._bodyPartElement?.isConnected ? this._bodyPartElement : null)
+      ?? this.element?.querySelector?.(".looter-shell")
+      ?? this.parts.body
+      ?? this.element;
+  }
+
+  get interactionElement() {
+    return this.window?.content
+      ?? this.element
+      ?? this.bodyElement;
+  }
+
+  _attachPartListeners(partId, htmlElement, options) {
+    super._attachPartListeners(partId, htmlElement, options);
+    if (partId === "body") this._bodyPartElement = htmlElement;
+  }
+
+  _findDropzoneByPoint(selector, event, root = this.bodyElement ?? this.element) {
+    if (!selector || !root?.querySelectorAll) return null;
+    const dragEvent = event?.originalEvent ?? event;
+    const x = Number(dragEvent?.clientX);
+    const y = Number(dragEvent?.clientY);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+
+    for (const zone of root.querySelectorAll(selector)) {
+      const rect = zone.getBoundingClientRect();
+      if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) return zone;
+    }
+
+    return null;
+  }
+
+  _findDropzoneFromEvent(selector, event, root = this.bodyElement ?? this.element) {
+    if (!selector) return null;
+    const path = typeof event?.composedPath === "function" ? event.composedPath() : [];
+    for (const node of path) {
+      if (node?.matches?.(selector)) return node;
+      if (node?.closest?.(selector)) return node.closest(selector);
+    }
+
+    return this._findDropzoneByPoint(selector, event, root)
+      ?? getEventTargetElement(event)?.closest?.(selector)
+      ?? null;
+  }
+
+  _bindAppDragDropController({ selector, callbacks = {}, fallbackElement = null } = {}) {
+    const DragDropController = getDragDropControllerClass();
+    const bindElement = fallbackElement ?? this.interactionElement;
+    if (typeof DragDropController !== "function" || !selector || !bindElement?.addEventListener) return;
+    if (this._dragDrop && this._dragDropBoundElement === bindElement && this._dragDropSelector === selector) return;
+
+    this._dragDrop = new DragDropController({
+      dropSelector: selector,
+      permissions: {
+        drop: () => true
+      },
+      callbacks
+    });
+    this._dragDrop.bind(bindElement);
+    this._dragDropBoundElement = bindElement;
+    this._dragDropSelector = selector;
+  }
+
+  async _runLooterAction(operation, logContext, userMessage) {
+    try {
+      return await operation();
+    } catch (err) {
+      console.error(`${LOOTER_ID} | ${logContext}`, err);
+      if (userMessage) ui.notifications.error(userMessage);
+      return undefined;
+    }
+  }
+}
+
+class LooterMonsterTableApp extends LooterApplicationV2 {
   constructor(options = {}) {
     super(options);
     this._monsterSort = { field: "name", direction: "asc" };
+    this._draftRows = sortMonsterRows(getMonsterTable().map(normalizeMonsterRow), this._monsterSort);
+    this._pendingFocusRowIndex = null;
+    this._bodyListenersAbort = null;
+    this._activeMonsterDropzone = null;
+    this._dragDrop = null;
+    this._dragDropBoundElement = null;
+    this._dragDropSelector = null;
     this._typePopover = null;
     this._boundDocumentPointerDown = this._onDocumentPointerDown.bind(this);
     this._boundWindowResize = this._repositionTypePopover.bind(this);
   }
 
-  static get defaultOptions() {
-    return foundry.utils.mergeObject(super.defaultOptions, {
+  static get DEFAULT_OPTIONS() {
+    const options = foundry.utils.mergeObject(super.DEFAULT_OPTIONS, {
       id: "looter-monster-table",
-      title: "Monster Registry",
-      template: `modules/${LOOTER_ID}/templates/monster-table.html`,
-      width: 1280,
-      height: 820,
-      resizable: true,
-      closeOnSubmit: false,
-      submitOnChange: false,
-      submitOnClose: false,
-      classes: ["looter-app", `theme-${getTheme()}`]
-    });
+      position: {
+        width: 1280,
+        height: 820
+      },
+      window: {
+        title: "Monster Registry"
+      }
+    }, { inplace: false });
+    options.classes = [...(options.classes ?? []), `theme-${getTheme()}`];
+    return options;
   }
 
-  getData() {
-    const profiles = getTreasureProfiles().map(normalizeProfile);
-    const rows = sortMonsterRows(getMonsterTable(), this._monsterSort).map((row, index) => ({
-      ...row,
-      index,
-      treasureTypesValue: (row.treasureTypes || []).join(", ")
-    }));
+  static get PARTS() {
+    return {
+      body: {
+        template: moduleAssetPath("templates/monster-table.html"),
+        root: true,
+        scrollable: [".looter-manager-table-wrap"]
+      }
+    };
+  }
+
+  async _prepareContext(_options) {
+    const rows = this._draftRows.map((row, index) => {
+      const normalized = normalizeMonsterRow(row);
+      return {
+        ...normalized,
+        index,
+        treasureTypesValue: normalized.treasureTypes.join(", ")
+      };
+    });
 
     return {
       rows,
@@ -878,69 +1230,212 @@ class LooterMonsterTableApp extends FormApplication {
     };
   }
 
-  activateListeners(html) {
-    super.activateListeners(html);
+  _attachPartListeners(partId, htmlElement, options) {
+    super._attachPartListeners(partId, htmlElement, options);
+    if (partId !== "body") return;
 
-    const importDropzone = html[0].querySelector("[data-import-dropzone]");
-    if (importDropzone) {
-      importDropzone.addEventListener("dragover", this._onMonsterDropOver.bind(this));
-      importDropzone.addEventListener("dragleave", this._onMonsterDropLeave.bind(this));
-      importDropzone.addEventListener("drop", this._onMonsterImportDrop.bind(this));
-    }
+    this._bindMonsterDragDropController(htmlElement);
+  }
 
-    html.find(".looter-sort-monsters").on("click", ev => {
-      ev.preventDefault();
-      const field = String(ev.currentTarget.dataset.field || "name");
-      if (this._monsterSort.field === field) this._monsterSort.direction = this._monsterSort.direction === "asc" ? "desc" : "asc";
-      else this._monsterSort = { field, direction: "asc" };
-      this.render(false);
-    });
-
-    html.find(".looter-type-selector").on("click", ev => {
-      ev.preventDefault();
-      this._toggleTypePopover(ev.currentTarget);
-    });
-
-    html.find(".looter-add-row").on("click", ev => {
-      ev.preventDefault();
-      const rows = this._collectMonsterRows(html[0]);
-      rows.push({ name: "", cr: 0, xp: 0, treasureTypes: [] });
-      setMonsterTable(rows).then(() => this.render(false));
-    });
-
-    html.find(".looter-save").on("click", ev => {
-      ev.preventDefault();
-      this._saveFromForm(html[0]);
-    });
-
-    html.find(".looter-delete-row").on("click", ev => {
-      ev.preventDefault();
-      const idx = Number(ev.currentTarget.dataset.index);
-      const rows = this._collectMonsterRows(html[0]);
-      rows.splice(idx, 1);
-      setMonsterTable(rows).then(() => this.render(false));
-    });
-
-    html.find(".looter-open-profiles").on("click", ev => {
-      ev.preventDefault();
-      openTreasureProfilesApp();
+  _bindMonsterDragDropController(fallbackElement = null) {
+    this._bindAppDragDropController({
+      selector: "[data-import-dropzone], [data-import-dropzone] *",
+      fallbackElement,
+      callbacks: {
+        dragenter: event => {
+          const zone = this._findMonsterDropzoneFromEvent(event);
+          if (zone) this._onMonsterDropOver(event, zone);
+        },
+        dragover: event => {
+          const zone = this._findMonsterDropzoneFromEvent(event);
+          if (zone) this._onMonsterDropOver(event, zone);
+        },
+        dragleave: event => {
+          const zone = this._findMonsterDropzoneFromEvent(event) ?? this._activeMonsterDropzone;
+          if (!zone) return;
+          const next = event.relatedTarget;
+          if (next && zone.contains?.(next)) return;
+          this._onMonsterDropLeave(event, zone);
+        },
+        drop: event => {
+          const zone = this._findMonsterDropzoneFromEvent(event) ?? this._activeMonsterDropzone;
+          if (zone) void this._onMonsterImportDrop(event, zone);
+        }
+      }
     });
   }
 
-  _collectMonsterRows(root) {
+  _onClickAction(event, target) {
+    const action = target.dataset.action;
+    switch (action) {
+      case "openProfiles":
+        event.preventDefault();
+        openTreasureProfilesApp();
+        return;
+      case "saveRows":
+        event.preventDefault();
+        void this._runLooterAction(
+          () => this._saveFromForm(),
+          "Monster Registry action failed",
+          "Looter couldn't save the Monster Registry."
+        );
+        return;
+      case "addRow":
+        event.preventDefault();
+        void this._runLooterAction(
+          () => this._addDraftRow(),
+          "Monster Registry action failed",
+          "Looter couldn't add a monster row."
+        );
+        return;
+      case "sortRows":
+        event.preventDefault();
+        void this._runLooterAction(
+          () => this._sortDraftRows(String(target.dataset.field || "name")),
+          "Monster Registry action failed",
+          "Looter couldn't sort the Monster Registry."
+        );
+        return;
+      case "toggleTreasureTypes":
+        event.preventDefault();
+        this._toggleTypePopover(target);
+        return;
+      case "deleteRow":
+        event.preventDefault();
+        void this._runLooterAction(
+          () => this._deleteDraftRow(Number(target.dataset.index)),
+          "Monster Registry action failed",
+          "Looter couldn't remove that monster row."
+        );
+        return;
+      default:
+        return super._onClickAction(event, target);
+    }
+  }
+
+  async _onRender(context, options) {
+    await super._onRender(context, options);
+    this._bindMonsterDragDropController();
+    this._bindMonsterBodyListeners();
+
+    const index = this._pendingFocusRowIndex;
+    if (!Number.isFinite(index)) return;
+    this._pendingFocusRowIndex = null;
+
+    requestAnimationFrame(() => {
+      const input = this.bodyElement?.querySelector(`[name="rows.${index}.name"]`);
+      input?.closest?.("tr")?.scrollIntoView?.({ block: "nearest" });
+      input?.focus?.();
+      input?.select?.();
+    });
+  }
+
+  _bindMonsterBodyListeners() {
+    this._bodyListenersAbort?.abort();
+    const root = this.bodyElement ?? this.element;
+    if (!root?.addEventListener) return;
+    const controller = new AbortController();
+    const listenerOptions = { signal: controller.signal };
+    const captureOptions = { capture: true, signal: controller.signal };
+    const doc = root.ownerDocument;
+    root.addEventListener("input", this._onMonsterFieldInput.bind(this), listenerOptions);
+    root.addEventListener("change", this._onMonsterFieldInput.bind(this), listenerOptions);
+    root.addEventListener("dragenter", this._onMonsterBodyDragOver.bind(this), captureOptions);
+    root.addEventListener("dragover", this._onMonsterBodyDragOver.bind(this), captureOptions);
+    root.addEventListener("dragleave", this._onMonsterBodyDragLeave.bind(this), captureOptions);
+    root.addEventListener("drop", this._onMonsterBodyDrop.bind(this), captureOptions);
+    const zone = root.querySelector?.("[data-import-dropzone]");
+    if (zone) {
+      const targets = [zone, ...zone.querySelectorAll("*")];
+      for (const target of targets) {
+        target.addEventListener("dragenter", event => this._onMonsterDropOver(event, zone), captureOptions);
+        target.addEventListener("dragover", event => this._onMonsterDropOver(event, zone), captureOptions);
+        target.addEventListener("dragleave", event => {
+          const next = event.relatedTarget;
+          if (next && zone.contains(next)) return;
+          this._onMonsterDropLeave(event, zone);
+        }, captureOptions);
+        target.addEventListener("drop", event => {
+          void this._onMonsterImportDrop(event, zone);
+        }, captureOptions);
+      }
+    }
+    doc?.addEventListener("dragenter", this._onMonsterDocumentDrag.bind(this), captureOptions);
+    doc?.addEventListener("dragover", this._onMonsterDocumentDrag.bind(this), captureOptions);
+    doc?.addEventListener("dragleave", this._onMonsterDocumentDragLeave.bind(this), captureOptions);
+    doc?.addEventListener("drop", this._onMonsterDocumentDrop.bind(this), captureOptions);
+    this._bodyListenersAbort = controller;
+  }
+
+  _updateDraftRowFromField(field) {
+    const row = field?.closest?.("tr[data-index]");
+    const index = Number(row?.dataset.index);
+    if (!Number.isFinite(index)) return;
+
+    const name = String(field.name || "");
+    const current = normalizeMonsterRow(this._draftRows[index] || {});
+    if (name.endsWith(".name")) current.name = String(field.value ?? "").trim();
+    else if (name.endsWith(".cr")) current.cr = clampNumber(field.value, 0);
+    else if (name.endsWith(".xp")) current.xp = clampNumber(field.value, 0);
+    else if (name.endsWith(".treasureTypes")) current.treasureTypes = treasureTypesFromString(field.value);
+    else return;
+
+    this._draftRows[index] = normalizeMonsterRow(current);
+  }
+
+  _onMonsterFieldInput(event) {
+    const target = getEventTargetElement(event);
+    if (!target?.matches?.('input[name^="rows."]')) return;
+    this._updateDraftRowFromField(target);
+  }
+
+  _collectMonsterRows(root = this.bodyElement, { includeBlank = false } = {}) {
     const rows = [];
-    for (const row of root.querySelectorAll("tbody.looter-monsters tr[data-index]")) {
-      const idx = Number(row.dataset.index);
-      if (!Number.isFinite(idx)) continue;
-      const name = row.querySelector(`[name="rows.${idx}.name"]`)?.value?.trim() || "";
-      const cr = clampNumber(row.querySelector(`[name="rows.${idx}.cr"]`)?.value, 0);
-      const xp = clampNumber(row.querySelector(`[name="rows.${idx}.xp"]`)?.value, 0);
-      const rawTreasureTypes = row.querySelector(`[name="rows.${idx}.treasureTypes"]`)?.value || "";
-      const treasureTypes = treasureTypesFromString(rawTreasureTypes);
-      if (!name) continue;
-      rows.push({ name, cr, xp, treasureTypes });
+    for (const row of root?.querySelectorAll?.("tbody.looter-monsters tr[data-index]") ?? []) {
+      const normalized = normalizeMonsterRow({
+        name: row.querySelector('input[name$=".name"]')?.value,
+        cr: row.querySelector('input[name$=".cr"]')?.value,
+        xp: row.querySelector('input[name$=".xp"]')?.value,
+        treasureTypes: row.querySelector('input[name$=".treasureTypes"]')?.value
+      });
+      if (!includeBlank && !normalized.name) continue;
+      rows.push(normalized);
     }
     return rows;
+  }
+
+  _syncDraftRowsFromRenderedInputs(root = this.bodyElement, { includeBlank = true } = {}) {
+    if (!root && !this.element) return this._draftRows;
+    const primaryRoot = root || this.element;
+    let rows = this._collectMonsterRows(primaryRoot, { includeBlank });
+    if (!rows.length && this.element && primaryRoot !== this.element) {
+      rows = this._collectMonsterRows(this.element, { includeBlank });
+    }
+    this._draftRows = rows;
+    return this._draftRows;
+  }
+
+  async _sortDraftRows(field) {
+    this._syncDraftRowsFromRenderedInputs();
+    if (this._monsterSort.field === field) this._monsterSort.direction = this._monsterSort.direction === "asc" ? "desc" : "asc";
+    else this._monsterSort = { field, direction: "asc" };
+    this._draftRows = sortMonsterRows(this._draftRows, this._monsterSort);
+    await this.render({ force: true });
+  }
+
+  async _addDraftRow() {
+    this._syncDraftRowsFromRenderedInputs();
+    this._draftRows.push(normalizeMonsterRow());
+    this._draftRows = sortMonsterRows(this._draftRows, this._monsterSort);
+    this._pendingFocusRowIndex = Math.max(this._draftRows.length - 1, 0);
+    await this.render({ force: true });
+  }
+
+  async _deleteDraftRow(index) {
+    this._syncDraftRowsFromRenderedInputs();
+    if (!Number.isFinite(index) || !this._draftRows[index]) return;
+    this._draftRows.splice(index, 1);
+    await this.render({ force: true });
   }
 
   _readRowTreasureTypes(row) {
@@ -952,6 +1447,11 @@ class LooterMonsterTableApp extends FormApplication {
     const normalized = [...new Set((types || []).map(titleCase).filter(Boolean))];
     const input = row?.querySelector('input[name$=".treasureTypes"]');
     if (input) input.value = normalized.join(", ");
+
+    const index = Number(row?.dataset?.index);
+    if (Number.isFinite(index) && this._draftRows[index]) {
+      this._draftRows[index].treasureTypes = normalized;
+    }
     const chips = row?.querySelector(".looter-type-selector-chips");
     if (chips) {
       chips.innerHTML = normalized.length
@@ -1040,7 +1540,7 @@ class LooterMonsterTableApp extends FormApplication {
   _onDocumentPointerDown(event) {
     const state = this._typePopover;
     if (!state) return;
-    const target = event.target;
+    const target = getEventTargetElement(event);
     if (state.el.contains(target) || state.button.contains(target)) return;
     this._closeTypePopover();
   }
@@ -1061,19 +1561,86 @@ class LooterMonsterTableApp extends FormApplication {
     zone.classList.toggle("is-drop-target", active);
   }
 
-  _onMonsterDropOver(event) {
+  _setActiveMonsterDropzone(zone) {
+    if (this._activeMonsterDropzone && this._activeMonsterDropzone !== zone) {
+      this._setMonsterDropState(this._activeMonsterDropzone, false);
+    }
+    this._activeMonsterDropzone = zone || null;
+    if (zone) this._setMonsterDropState(zone, true);
+  }
+
+  _findMonsterDropzoneByPoint(event) {
+    return this._findDropzoneByPoint("[data-import-dropzone]", event);
+  }
+
+  _findMonsterDropzoneFromEvent(event) {
+    return this._findDropzoneFromEvent("[data-import-dropzone]", event);
+  }
+
+  _onMonsterDocumentDrag(event) {
+    const zone = this._findMonsterDropzoneByPoint(event);
+    if (!zone) {
+      this._setActiveMonsterDropzone(null);
+      return;
+    }
+    this._setActiveMonsterDropzone(zone);
+    this._onMonsterDropOver(event, zone);
+  }
+
+  _onMonsterDocumentDragLeave(event) {
+    const zone = this._findMonsterDropzoneByPoint(event);
+    if (zone) return;
+    this._setActiveMonsterDropzone(null);
+  }
+
+  _onMonsterDocumentDrop(event) {
+    const zone = this._findMonsterDropzoneByPoint(event);
+    this._setActiveMonsterDropzone(null);
+    if (!zone) return;
+    void this._onMonsterImportDrop(event, zone);
+  }
+
+  _onMonsterBodyDragOver(event) {
+    const zone = this._findMonsterDropzoneFromEvent(event);
+    if (!zone) return;
+    this._onMonsterDropOver(event, zone);
+  }
+
+  _onMonsterBodyDragLeave(event) {
+    const zone = this._findMonsterDropzoneFromEvent(event);
+    if (!zone) return;
+    const next = event.relatedTarget;
+    if (next && zone.contains(next)) return;
+    this._onMonsterDropLeave(event, zone);
+  }
+
+  _onMonsterBodyDrop(event) {
+    const zone = this._findMonsterDropzoneFromEvent(event);
+    if (!zone) return;
+    void this._onMonsterImportDrop(event, zone);
+  }
+
+  _onMonsterDropOver(event, target = event.currentTarget) {
     event.preventDefault();
-    this._setMonsterDropState(event.currentTarget, true);
+    event.stopPropagation();
+    this._setMonsterDropState(target, true);
     if ((event.originalEvent ?? event).dataTransfer) (event.originalEvent ?? event).dataTransfer.dropEffect = "copy";
   }
 
-  _onMonsterDropLeave(event) {
-    this._setMonsterDropState(event.currentTarget, false);
+  _onMonsterDropLeave(event, target = event.currentTarget) {
+    event.stopPropagation();
+    this._setMonsterDropState(target, false);
   }
 
-  async _importActorToRows(event) {
+  async _importActorToRows(event, target = event.currentTarget) {
+    const dragEvent = event?.originalEvent ?? event;
+    if (dragEvent?._looterMonsterDropHandled) return;
+    if (dragEvent) dragEvent._looterMonsterDropHandled = true;
+
     event.preventDefault();
-    this._setMonsterDropState(event.currentTarget, false);
+    event.stopPropagation();
+    this._setActiveMonsterDropzone(null);
+    this._setMonsterDropState(target, false);
 
     const actor = await resolveDroppedActor(event);
     if (!actor) {
@@ -1085,12 +1652,11 @@ class LooterMonsterTableApp extends FormApplication {
       return;
     }
 
-    const root = this.form ?? this.element?.[0];
-    const rows = root ? this._collectMonsterRows(root) : getMonsterTable();
-    const imported = monsterRowFromActor(actor);
+    this._syncDraftRowsFromRenderedInputs();
+    const imported = normalizeMonsterRow(monsterRowFromActor(actor));
     if (!imported.name) return;
 
-    const existingIndex = rows.findIndex(row => normalizeName(row.name) === normalizeName(imported.name));
+    const existingIndex = this._draftRows.findIndex(row => normalizeName(row.name) === normalizeName(imported.name));
     if (existingIndex >= 0) {
       const shouldOverwrite = await Dialog.confirm({
         title: "Overwrite Monster Entry?",
@@ -1104,57 +1670,103 @@ class LooterMonsterTableApp extends FormApplication {
         return;
       }
 
-      rows[existingIndex] = imported;
-      await setMonsterTable(rows);
-      ui.notifications.info(`Looter updated ${imported.name}.`);
-      this.render(false);
+      this._draftRows[existingIndex] = imported;
+      this._draftRows = sortMonsterRows(this._draftRows, this._monsterSort);
+      ui.notifications.info(`Looter updated ${imported.name} in the draft registry. Click Save to persist.`);
+      await this.render({ force: true });
       return;
     }
 
-    rows.push(imported);
-    await setMonsterTable(rows);
-    ui.notifications.info(`Looter imported ${imported.name}.`);
-    this.render(false);
+    this._draftRows.push(imported);
+    this._draftRows = sortMonsterRows(this._draftRows, this._monsterSort);
+    ui.notifications.info(`Looter imported ${imported.name} into the draft registry. Click Save to persist.`);
+    await this.render({ force: true });
   }
 
-  async _onMonsterImportDrop(event) {
-    await this._importActorToRows(event);
+  async _onMonsterImportDrop(event, target = event.currentTarget) {
+    await this._runLooterAction(
+      () => this._importActorToRows(event, target),
+      "Monster import failed",
+      "Looter couldn't import that actor."
+    );
   }
 
-  async _saveFromForm(root) {
-    const rows = this._collectMonsterRows(root);
+  async _saveFromForm() {
+    this._syncDraftRowsFromRenderedInputs();
+    const rows = this._draftRows
+      .map(normalizeMonsterRow)
+      .filter(row => row.name);
+    if (!rows.length) {
+      const rawNames = Array.from(this.element?.querySelectorAll?.('tbody.looter-monsters input[name$=".name"]') ?? [])
+        .map(input => String(input?.value ?? "").trim())
+        .filter(Boolean);
+      if (rawNames.length) {
+        console.warn(`${LOOTER_ID} | Monster Registry save found visible names but no collected rows.`, {
+          rawNames,
+          bodyElement: this.bodyElement,
+          element: this.element
+        });
+      }
+    }
     await setMonsterTable(rows);
+    this._draftRows = sortMonsterRows(rows, this._monsterSort);
     ui.notifications.info("Looter monster registry saved.");
-    this.render(false);
+    await this.render({ force: true });
   }
 
-  async close(options) {
-    return super.close(options);
+  async _preClose(options) {
+    this._bodyListenersAbort?.abort();
+    this._bodyListenersAbort = null;
+    this._activeMonsterDropzone = null;
+    this._dragDrop = null;
+    this._dragDropBoundElement = null;
+    this._dragDropSelector = null;
+    this._closeTypePopover();
+    return super._preClose(options);
   }
-
-  async _updateObject(_event, _formData) {}
 }
 
 
-class LooterTreasureProfilesApp extends FormApplication {
-  static get defaultOptions() {
-    return foundry.utils.mergeObject(super.defaultOptions, {
-      id: "looter-treasure-profiles",
-      title: "Treasure Profiles",
-      template: `modules/${LOOTER_ID}/templates/treasure-profiles.html`,
-      width: 1280,
-      height: 820,
-      resizable: true,
-      closeOnSubmit: false,
-      submitOnChange: false,
-      submitOnClose: false,
-      classes: ["looter-app", `theme-${getTheme()}`]
-    });
+class LooterTreasureProfilesApp extends LooterApplicationV2 {
+  constructor(options = {}) {
+    super(options);
+    this._draftProfiles = getTreasureProfiles().map(normalizeProfile);
+    this._pendingFocusProfileIndex = null;
+    this._bodyListenersAbort = null;
+    this._activeTableDropzone = null;
+    this._dragDrop = null;
+    this._dragDropBoundElement = null;
+    this._dragDropSelector = null;
   }
 
-  getData() {
+  static get DEFAULT_OPTIONS() {
+    const options = foundry.utils.mergeObject(super.DEFAULT_OPTIONS, {
+      id: "looter-treasure-profiles",
+      position: {
+        width: 1280,
+        height: 820
+      },
+      window: {
+        title: "Treasure Profiles"
+      }
+    }, { inplace: false });
+    options.classes = [...(options.classes ?? []), `theme-${getTheme()}`];
+    return options;
+  }
+
+  static get PARTS() {
     return {
-      profiles: getTreasureProfiles().map((profile, index) => {
+      body: {
+        template: moduleAssetPath("templates/treasure-profiles.html"),
+        root: true,
+        scrollable: [".looter-profile-scroll-wrap"]
+      }
+    };
+  }
+
+  async _prepareContext(_options) {
+    return {
+      profiles: this._draftProfiles.map((profile, index) => {
         const normalized = normalizeProfile(profile);
         return {
           ...normalized,
@@ -1168,59 +1780,218 @@ class LooterTreasureProfilesApp extends FormApplication {
     };
   }
 
-  activateListeners(html) {
-    super.activateListeners(html);
+  _attachPartListeners(partId, htmlElement, options) {
+    super._attachPartListeners(partId, htmlElement, options);
+    if (partId !== "body") return;
 
-    html.find(".looter-open-monsters").on("click", ev => {
-      ev.preventDefault();
-      openMonsterTableApp();
+    this._bindProfileDragDropController(htmlElement);
+  }
+
+  _bindProfileDragDropController(fallbackElement = null) {
+    this._bindAppDragDropController({
+      selector: ".looter-table-dropzone[data-index], .looter-table-dropzone[data-index] *",
+      fallbackElement,
+      callbacks: {
+        dragenter: event => {
+          const zone = this._findTableDropzoneFromEvent(event);
+          if (zone) this._onTableLinkDragOver(event, zone);
+        },
+        dragover: event => {
+          const zone = this._findTableDropzoneFromEvent(event);
+          if (zone) this._onTableLinkDragOver(event, zone);
+        },
+        dragleave: event => {
+          const zone = this._findTableDropzoneFromEvent(event) ?? this._activeTableDropzone;
+          if (!zone) return;
+          const next = event.relatedTarget;
+          if (next && zone.contains?.(next)) return;
+          this._onTableLinkDragLeave(event, zone);
+        },
+        drop: event => {
+          const zone = this._findTableDropzoneFromEvent(event) ?? this._activeTableDropzone;
+          if (zone) void this._onTableLinkDrop(event, zone);
+        }
+      }
     });
+  }
 
-    html.find(".looter-add-profile").on("click", ev => {
-      ev.preventDefault();
-      const profiles = getTreasureProfiles();
-      profiles.push({ type: "Any", tier: "0-4", currency: defaultCurrencyBlock(), tableRolls: "1", itemTable: tableName("Any", "0-4") });
-      setTreasureProfiles(profiles).then(() => this.render(false));
-    });
-
-    html.find(".looter-delete-profile").on("click", ev => {
-      ev.preventDefault();
-      const idx = Number(ev.currentTarget.dataset.index);
-      const profiles = getTreasureProfiles();
-      profiles.splice(idx, 1);
-      setTreasureProfiles(profiles).then(() => this.render(false));
-    });
-
-    html.find(".looter-save").on("click", ev => {
-      ev.preventDefault();
-      this._saveFromForm(html[0]);
-    });
-
-    html.find(".looter-seed-tables").on("click", async ev => {
-      ev.preventDefault();
-      await ensureWorldTables();
-      ui.notifications.info("Looter starter item tables are ready in the Roll Tables directory.");
-    });
-
-    html.find(".looter-seed-profiles").on("click", async ev => {
-      ev.preventDefault();
-      await ensureTreasureProfiles();
-      ui.notifications.info("Looter starter treasure profiles are ready.");
-      this.render(false);
-    });
-
-    html.find(".looter-clear-table").on("click", async ev => {
-      ev.preventDefault();
-      const idx = Number(ev.currentTarget.dataset.index);
-      if (!Number.isFinite(idx)) return;
-      await this._clearLinkedTable(idx);
-    });
-
-    for (const zone of html[0].querySelectorAll(".looter-table-dropzone[data-index]")) {
-      zone.addEventListener("dragover", this._onTableLinkDragOver.bind(this));
-      zone.addEventListener("dragleave", this._onTableLinkDragLeave.bind(this));
-      zone.addEventListener("drop", this._onTableLinkDrop.bind(this));
+  _onClickAction(event, target) {
+    const action = target.dataset.action;
+    switch (action) {
+      case "openMonsters":
+        event.preventDefault();
+        openMonsterTableApp();
+        return;
+      case "addProfile":
+        event.preventDefault();
+        void this._runLooterAction(
+          () => this._addDraftProfile(),
+          "Treasure Profiles action failed",
+          "Looter couldn't add a treasure profile."
+        );
+        return;
+      case "deleteProfile":
+        event.preventDefault();
+        void this._runLooterAction(
+          () => this._deleteDraftProfile(Number(target.dataset.index)),
+          "Treasure Profiles action failed",
+          "Looter couldn't remove that treasure profile."
+        );
+        return;
+      case "saveProfiles":
+        event.preventDefault();
+        void this._runLooterAction(
+          () => this._saveFromForm(),
+          "Treasure Profiles action failed",
+          "Looter couldn't save the Treasure Profiles."
+        );
+        return;
+      case "seedTables":
+        event.preventDefault();
+        void this._runLooterAction(
+          async () => {
+            await ensureWorldTables();
+            ui.notifications.info("Looter starter item tables are ready in the Roll Tables directory.");
+          },
+          "Treasure Profiles action failed",
+          "Looter couldn't seed the starter item tables."
+        );
+        return;
+      case "seedProfiles":
+        event.preventDefault();
+        void this._runLooterAction(
+          () => this._seedProfiles(),
+          "Treasure Profiles action failed",
+          "Looter couldn't seed the starter treasure profiles."
+        );
+        return;
+      case "clearTable":
+        event.preventDefault();
+        void this._runLooterAction(
+          () => this._clearLinkedTable(Number(target.dataset.index)),
+          "Treasure Profiles action failed",
+          "Looter couldn't clear the linked RollTable."
+        );
+        return;
+      default:
+        return super._onClickAction(event, target);
     }
+  }
+
+  async _onRender(context, options) {
+    await super._onRender(context, options);
+    this._bindProfileDragDropController();
+    this._bindProfileBodyListeners();
+
+    const index = this._pendingFocusProfileIndex;
+    if (!Number.isFinite(index)) return;
+    this._pendingFocusProfileIndex = null;
+
+    requestAnimationFrame(() => {
+      const input = this.bodyElement?.querySelector(`[name="profiles.${index}.type"]`);
+      input?.closest?.("tr")?.scrollIntoView?.({ block: "nearest" });
+      input?.focus?.();
+      input?.select?.();
+    });
+  }
+
+  _bindProfileBodyListeners() {
+    this._bodyListenersAbort?.abort();
+    const root = this.bodyElement ?? this.element;
+    if (!root?.addEventListener) return;
+    const controller = new AbortController();
+    const listenerOptions = { signal: controller.signal };
+    const captureOptions = { capture: true, signal: controller.signal };
+    const doc = root.ownerDocument;
+    root.addEventListener("input", this._onProfileFieldInput.bind(this), listenerOptions);
+    root.addEventListener("change", this._onProfileFieldInput.bind(this), listenerOptions);
+    root.addEventListener("dragenter", this._onProfileBodyDragOver.bind(this), captureOptions);
+    root.addEventListener("dragover", this._onProfileBodyDragOver.bind(this), captureOptions);
+    root.addEventListener("dragleave", this._onProfileBodyDragLeave.bind(this), captureOptions);
+    root.addEventListener("drop", this._onProfileBodyDrop.bind(this), captureOptions);
+    for (const zone of root.querySelectorAll?.(".looter-table-dropzone[data-index]") ?? []) {
+      const targets = [zone, ...zone.querySelectorAll("*")];
+      for (const target of targets) {
+        target.addEventListener("dragenter", event => this._onTableLinkDragOver(event, zone), captureOptions);
+        target.addEventListener("dragover", event => this._onTableLinkDragOver(event, zone), captureOptions);
+        target.addEventListener("dragleave", event => {
+          const next = event.relatedTarget;
+          if (next && zone.contains(next)) return;
+          this._onTableLinkDragLeave(event, zone);
+        }, captureOptions);
+        target.addEventListener("drop", event => {
+          void this._onTableLinkDrop(event, zone);
+        }, captureOptions);
+      }
+    }
+    doc?.addEventListener("dragenter", this._onProfileDocumentDrag.bind(this), captureOptions);
+    doc?.addEventListener("dragover", this._onProfileDocumentDrag.bind(this), captureOptions);
+    doc?.addEventListener("dragleave", this._onProfileDocumentDragLeave.bind(this), captureOptions);
+    doc?.addEventListener("drop", this._onProfileDocumentDrop.bind(this), captureOptions);
+    this._bodyListenersAbort = controller;
+  }
+
+  _updateDraftProfileFromField(field) {
+    const row = field?.closest?.("tr[data-index]");
+    const index = Number(row?.dataset.index);
+    if (!Number.isFinite(index)) return;
+
+    const match = /^profiles\.(\d+)\.(.+)$/.exec(String(field.name || ""));
+    if (!match) return;
+
+    const current = normalizeProfile(this._draftProfiles[index] || {});
+    const path = match[2];
+
+    if (path === "type") current.type = String(field.value ?? "").trim();
+    else if (path === "tier") current.tier = String(field.value ?? "0-4");
+    else if (path === "tableRolls") current.tableRolls = String(field.value ?? "1");
+    else if (path === "itemTable") current.itemTable = String(field.value ?? "").trim();
+    else if (path.startsWith("currency.")) {
+      const denom = path.slice("currency.".length);
+      if (!["pp", "gp", "ep", "sp", "cp"].includes(denom)) return;
+      current.currency[denom] = String(field.value ?? "").trim();
+    } else return;
+
+    this._draftProfiles[index] = normalizeProfile(current);
+  }
+
+  _onProfileFieldInput(event) {
+    const target = getEventTargetElement(event);
+    if (!target?.matches?.('[name^="profiles."]')) return;
+    this._updateDraftProfileFromField(target);
+  }
+
+  _collectProfiles(root = this.bodyElement, { includeBlank = false } = {}) {
+    const profiles = [];
+    for (const row of root?.querySelectorAll?.("tbody.looter-profiles tr[data-index]") ?? []) {
+      const profile = normalizeProfile({
+        type: row.querySelector('input[name$=".type"]')?.value || "",
+        tier: String(row.querySelector('select[name$=".tier"]')?.value || "0-4"),
+        currency: {
+          pp: row.querySelector('input[name$=".currency.pp"]')?.value || "",
+          gp: row.querySelector('input[name$=".currency.gp"]')?.value || "",
+          ep: row.querySelector('input[name$=".currency.ep"]')?.value || "",
+          sp: row.querySelector('input[name$=".currency.sp"]')?.value || "",
+          cp: row.querySelector('input[name$=".currency.cp"]')?.value || ""
+        },
+        tableRolls: row.querySelector('input[name$=".tableRolls"]')?.value || "1",
+        itemTable: row.querySelector('input[name$=".itemTable"]')?.value || ""
+      });
+      if (!includeBlank && !profile.type) continue;
+      profiles.push(profile);
+    }
+    return profiles;
+  }
+
+  _syncDraftProfilesFromRenderedInputs(root = this.bodyElement, { includeBlank = true } = {}) {
+    if (!root && !this.element) return this._draftProfiles;
+    const primaryRoot = root || this.element;
+    let profiles = this._collectProfiles(primaryRoot, { includeBlank });
+    if (!profiles.length && this.element && primaryRoot !== this.element) {
+      profiles = this._collectProfiles(this.element, { includeBlank });
+    }
+    this._draftProfiles = profiles;
+    return this._draftProfiles;
   }
 
   _setTableLinkDropState(target, active) {
@@ -1229,21 +2000,88 @@ class LooterTreasureProfilesApp extends FormApplication {
     zone.classList.toggle("is-drop-target", active);
   }
 
-  _onTableLinkDragOver(event) {
+  _setActiveTableDropzone(zone) {
+    if (this._activeTableDropzone && this._activeTableDropzone !== zone) {
+      this._setTableLinkDropState(this._activeTableDropzone, false);
+    }
+    this._activeTableDropzone = zone || null;
+    if (zone) this._setTableLinkDropState(zone, true);
+  }
+
+  _findTableDropzoneByPoint(event) {
+    return this._findDropzoneByPoint(".looter-table-dropzone[data-index]", event);
+  }
+
+  _findTableDropzoneFromEvent(event) {
+    return this._findDropzoneFromEvent(".looter-table-dropzone[data-index]", event);
+  }
+
+  _onProfileDocumentDrag(event) {
+    const zone = this._findTableDropzoneByPoint(event);
+    if (!zone) {
+      this._setActiveTableDropzone(null);
+      return;
+    }
+    this._setActiveTableDropzone(zone);
+    this._onTableLinkDragOver(event, zone);
+  }
+
+  _onProfileDocumentDragLeave(event) {
+    const zone = this._findTableDropzoneByPoint(event);
+    if (zone) return;
+    this._setActiveTableDropzone(null);
+  }
+
+  _onProfileDocumentDrop(event) {
+    const zone = this._findTableDropzoneByPoint(event);
+    this._setActiveTableDropzone(null);
+    if (!zone) return;
+    void this._onTableLinkDrop(event, zone);
+  }
+
+  _onProfileBodyDragOver(event) {
+    const zone = this._findTableDropzoneFromEvent(event);
+    if (!zone) return;
+    this._onTableLinkDragOver(event, zone);
+  }
+
+  _onProfileBodyDragLeave(event) {
+    const zone = this._findTableDropzoneFromEvent(event);
+    if (!zone) return;
+    const next = event.relatedTarget;
+    if (next && zone.contains(next)) return;
+    this._onTableLinkDragLeave(event, zone);
+  }
+
+  _onProfileBodyDrop(event) {
+    const zone = this._findTableDropzoneFromEvent(event);
+    if (!zone) return;
+    void this._onTableLinkDrop(event, zone);
+  }
+
+  _onTableLinkDragOver(event, target = event.currentTarget) {
     event.preventDefault();
-    this._setTableLinkDropState(event.currentTarget, true);
+    event.stopPropagation();
+    this._setTableLinkDropState(target, true);
     if ((event.originalEvent ?? event).dataTransfer) (event.originalEvent ?? event).dataTransfer.dropEffect = "copy";
   }
 
-  _onTableLinkDragLeave(event) {
-    this._setTableLinkDropState(event.currentTarget, false);
+  _onTableLinkDragLeave(event, target = event.currentTarget) {
+    event.stopPropagation();
+    this._setTableLinkDropState(target, false);
   }
 
-  async _onTableLinkDrop(event) {
-    event.preventDefault();
-    this._setTableLinkDropState(event.currentTarget, false);
+  async _onTableLinkDrop(event, target = event.currentTarget) {
+    const dragEvent = event?.originalEvent ?? event;
+    if (dragEvent?._looterTableDropHandled) return;
+    if (dragEvent) dragEvent._looterTableDropHandled = true;
 
-    const zone = event.currentTarget?.closest?.(".looter-table-dropzone") || event.currentTarget;
+    event.preventDefault();
+    event.stopPropagation();
+    this._setActiveTableDropzone(null);
+    this._setTableLinkDropState(target, false);
+
+    const zone = target?.closest?.(".looter-table-dropzone") || target;
     const index = Number(zone?.dataset.index);
     if (!Number.isFinite(index)) return;
 
@@ -1256,90 +2094,80 @@ class LooterTreasureProfilesApp extends FormApplication {
     await this._linkTableReference(index, dropped.reference);
   }
 
+  async _addDraftProfile() {
+    this._syncDraftProfilesFromRenderedInputs();
+    this._draftProfiles.push(normalizeProfile({
+      type: "Any",
+      tier: "0-4",
+      currency: defaultCurrencyBlock(),
+      tableRolls: "1",
+      itemTable: tableName("Any", "0-4")
+    }));
+    this._pendingFocusProfileIndex = Math.max(this._draftProfiles.length - 1, 0);
+    await this.render({ force: true });
+  }
+
+  async _deleteDraftProfile(index) {
+    this._syncDraftProfilesFromRenderedInputs();
+    if (!Number.isFinite(index) || !this._draftProfiles[index]) return;
+    this._draftProfiles.splice(index, 1);
+    await this.render({ force: true });
+  }
+
+  async _seedProfiles() {
+    await ensureTreasureProfiles();
+    this._draftProfiles = getTreasureProfiles().map(normalizeProfile);
+    ui.notifications.info("Looter starter treasure profiles are ready.");
+    await this.render({ force: true });
+  }
+
   async _linkTableReference(index, reference) {
-    const root = this.form ?? this.element?.[0];
-    if (!root) return;
-    await this._saveFromForm(root, { notify: false, rerender: false });
-    const profiles = getTreasureProfiles().map(normalizeProfile);
-    if (!profiles[index]) return;
-    profiles[index].itemTable = reference;
-    await setTreasureProfiles(profiles);
-    const displayName = getRollTableDisplayName(reference);
-    const row = root.querySelector(`tbody.looter-profiles tr[data-index="${index}"]`);
-    const hiddenInput = row?.querySelector(`[name="profiles.${index}.itemTable"]`);
-    const displayInput = row?.querySelector(".looter-table-display");
-    if (hiddenInput) hiddenInput.value = reference;
-    if (displayInput) {
-      displayInput.value = displayName;
-      displayInput.title = displayName;
-    }
-    ui.notifications.info(`Looter linked ${getRollTableDisplayName(reference)}.`);
+    this._syncDraftProfilesFromRenderedInputs();
+    if (!Number.isFinite(index) || !this._draftProfiles[index]) return;
+    this._draftProfiles[index].itemTable = reference;
+    ui.notifications.info(`Looter linked ${getRollTableDisplayName(reference)} in the draft profile. Click Save to persist.`);
+    await this.render({ force: true });
   }
 
   async _clearLinkedTable(index) {
-    const root = this.form ?? this.element?.[0];
-    if (!root) return;
-
-    await this._saveFromForm(root, { notify: false, rerender: false });
-
-    const profiles = getTreasureProfiles().map(normalizeProfile);
-    if (!profiles[index]) return;
-
-    profiles[index].itemTable = "";
-    await setTreasureProfiles(profiles);
-
-    const row = root.querySelector(`tbody.looter-profiles tr[data-index="${index}"]`);
-    const hiddenInput = row?.querySelector(`[name="profiles.${index}.itemTable"]`);
-    const displayInput = row?.querySelector(".looter-table-display");
-    if (hiddenInput) hiddenInput.value = "";
-    if (displayInput) {
-      displayInput.value = "";
-      displayInput.title = "";
-    }
-
-    ui.notifications.info("Looter cleared the linked RollTable for that profile.");
+    this._syncDraftProfilesFromRenderedInputs();
+    if (!Number.isFinite(index) || !this._draftProfiles[index]) return;
+    this._draftProfiles[index].itemTable = "";
+    ui.notifications.info("Looter cleared the linked RollTable in the draft profile. Click Save to persist.");
+    await this.render({ force: true });
   }
 
-  async _saveFromForm(root, { notify = true, rerender = true } = {}) {
-    const profiles = [];
-    for (const row of root.querySelectorAll("tbody.looter-profiles tr[data-index]")) {
-      const idx = Number(row.dataset.index);
-      if (!Number.isFinite(idx)) continue;
-      const type = titleCase(row.querySelector(`[name="profiles.${idx}.type"]`)?.value || "");
-      const tier = String(row.querySelector(`[name="profiles.${idx}.tier"]`)?.value || "0-4");
-      if (!type) continue;
-      profiles.push(normalizeProfile({
-        type,
-        tier,
-        currency: {
-          pp: row.querySelector(`[name="profiles.${idx}.currency.pp"]`)?.value || "",
-          gp: row.querySelector(`[name="profiles.${idx}.currency.gp"]`)?.value || "",
-          ep: row.querySelector(`[name="profiles.${idx}.currency.ep"]`)?.value || "",
-          sp: row.querySelector(`[name="profiles.${idx}.currency.sp"]`)?.value || "",
-          cp: row.querySelector(`[name="profiles.${idx}.currency.cp"]`)?.value || ""
-        },
-        tableRolls: row.querySelector(`[name="profiles.${idx}.tableRolls"]`)?.value || "1",
-        itemTable: row.querySelector(`[name="profiles.${idx}.itemTable"]`)?.value || ""
-      }));
-    }
-
+  async _saveFromForm({ notify = true, rerender = true } = {}) {
+    this._syncDraftProfilesFromRenderedInputs();
+    const profiles = this._draftProfiles
+      .map(normalizeProfile)
+      .filter(profile => profile.type);
     await setTreasureProfiles(profiles);
+    this._draftProfiles = profiles.map(normalizeProfile);
     if (notify) ui.notifications.info("Looter treasure profiles saved.");
-    if (rerender) this.render(false);
+    if (rerender) await this.render({ force: true });
   }
 
-  async close(options) {
-    return super.close(options);
+  async _preClose(options) {
+    this._bodyListenersAbort?.abort();
+    this._bodyListenersAbort = null;
+    this._activeTableDropzone = null;
+    this._dragDrop = null;
+    this._dragDropBoundElement = null;
+    this._dragDropSelector = null;
+    return super._preClose(options);
   }
-
-  async _updateObject(_event, _formData) {}
 }
 
-class LooterEncounterApp extends FormApplication {
+class LooterEncounterApp extends LooterApplicationV2 {
   constructor(snapshot, options = {}) {
     super(options);
     this.snapshot = clone(snapshot);
-    this.state = {
+    this._bodyListenersAbort = null;
+    this._activeEncounterDropzone = null;
+    this._encounterDraggedItemIndex = null;
+    this._encounterDraggedItemRow = null;
+    this.rewardsState = {
       enemies: clone(snapshot.enemies),
       players: snapshot.players.map(p => ({ ...p })),
       xp: clampNumber(snapshot.totals.xp, 0),
@@ -1348,208 +2176,425 @@ class LooterEncounterApp extends FormApplication {
     };
   }
 
-  static get defaultOptions() {
-    return foundry.utils.mergeObject(super.defaultOptions, {
+  static get DEFAULT_OPTIONS() {
+    const options = foundry.utils.mergeObject(super.DEFAULT_OPTIONS, {
       id: "looter-encounter-rewards",
-      title: "Looter Rewards",
-      template: `modules/${LOOTER_ID}/templates/encounter-rewards.html`,
-      width: 1180,
-      height: 760,
-      resizable: true,
-      closeOnSubmit: false,
-      submitOnChange: false,
-      submitOnClose: false,
-      classes: ["looter-app", "looter-encounter", `theme-${getTheme()}`]
-    });
+      position: {
+        width: 1180,
+        height: 760
+      },
+      window: {
+        title: "Looter Rewards"
+      }
+    }, { inplace: false });
+    options.classes = [...(options.classes ?? []), "looter-encounter", `theme-${getTheme()}`];
+    return options;
   }
 
-  getData() {
-    const items = this.state.items.map((item, index) => ({ ...item, index }));
-    const players = this.state.players.map(player => ({
+  static get PARTS() {
+    return {
+      body: {
+        template: moduleAssetPath("templates/encounter-rewards.html"),
+        root: true,
+        scrollable: [".looter-enemy-list", ".looter-player-list", ".looter-loot-scroll"]
+      }
+    };
+  }
+
+  async _prepareContext(_options) {
+    const items = this.rewardsState.items.map((item, index) => ({ ...item, index }));
+    const players = this.rewardsState.players.map(player => ({
       ...player,
       assignedItems: items.filter(item => item.assignee === player.actorId),
     }));
     const unassignedItems = items.filter(item => !item.assignee);
 
     return {
-      enemies: stackEnemiesForDisplay(this.state.enemies),
+      enemies: stackEnemiesForDisplay(this.rewardsState.enemies),
       players,
       items: unassignedItems,
-      xp: this.state.xp,
-      currency: this.state.currency,
+      xp: this.rewardsState.xp,
+      currency: this.rewardsState.currency,
       useXp: getUseXp()
     };
   }
 
-  _captureScrollPositions(root = this.form ?? this.element?.[0]) {
-    return {
-      enemies: root?.querySelector(".looter-enemy-list")?.scrollTop ?? 0,
-      players: root?.querySelector(".looter-player-list")?.scrollTop ?? 0,
-      loot: root?.querySelector(".looter-loot-scroll")?.scrollTop ?? 0
-    };
+  async _renderPreservingScroll() {
+    await this.render({ force: true });
   }
 
-  async _renderPreservingScroll(scrollPositions = null) {
-    const positions = scrollPositions ?? this._captureScrollPositions();
-    this.render(false);
-    await new Promise(resolve => requestAnimationFrame(() => resolve()));
-    const root = this.form ?? this.element?.[0];
+  async _onRender(context, options) {
+    await super._onRender(context, options);
+    this._bindEncounterBodyListeners();
+  }
+
+  _onClickAction(event, target) {
+    const action = target.dataset.action;
+    switch (action) {
+      case "rerollRewards":
+        event.preventDefault();
+        void this._runLooterAction(
+          () => this._reroll(),
+          "Encounter rewards action failed",
+          "Looter couldn't reroll the encounter rewards."
+        );
+        return;
+      case "sendSummary":
+        event.preventDefault();
+        void this._runLooterAction(
+          () => this._sendSummaryToChat(),
+          "Encounter rewards action failed",
+          "Looter couldn't send the reward summary to chat."
+        );
+        return;
+      case "applyRewards":
+        event.preventDefault();
+        void this._runLooterAction(
+          () => this._applyRewards(),
+          "Encounter rewards action failed",
+          "Looter couldn't apply the rewards."
+        );
+        return;
+      case "rerollEnemy":
+        event.preventDefault();
+        event.stopPropagation();
+        void this._runLooterAction(
+          () => this._rerollEnemyRewards(String(target.dataset.indexes || "")),
+          "Encounter rewards action failed",
+          "Looter couldn't reroll that enemy's rewards."
+        );
+        return;
+      case "rerollItem":
+        event.preventDefault();
+        event.stopPropagation();
+        void this._runLooterAction(
+          () => this._rerollLootItem(Number(target.dataset.index)),
+          "Encounter rewards action failed",
+          "Looter couldn't reroll that loot item."
+        );
+        return;
+      case "unassignItem":
+        event.preventDefault();
+        void this._runLooterAction(
+          () => this._unassignItem(Number(target.dataset.index)),
+          "Encounter rewards action failed",
+          "Looter couldn't return that item to the loot list."
+        );
+        return;
+      default:
+        return super._onClickAction(event, target);
+    }
+  }
+
+  _bindEncounterBodyListeners() {
+    this._bodyListenersAbort?.abort();
+    const root = this.bodyElement ?? this.element;
+    if (!root?.addEventListener) return;
+
+    const controller = new AbortController();
+    const listenerOptions = { signal: controller.signal };
+    const captureOptions = { capture: true, signal: controller.signal };
+    const doc = root.ownerDocument;
+
+    root.addEventListener("click", this._onEncounterBodyClick.bind(this), listenerOptions);
+
+    for (const row of root.querySelectorAll?.(".looter-item-row[data-index]") ?? []) {
+      row.draggable = true;
+    }
+
+    for (const card of root.querySelectorAll?.(".looter-player-card") ?? []) {
+      const targets = [card, ...card.querySelectorAll("*")];
+      for (const target of targets) {
+        target.addEventListener("dragenter", event => this._onEncounterDropZoneOver(event, card), captureOptions);
+        target.addEventListener("dragover", event => this._onEncounterDropZoneOver(event, card), captureOptions);
+        target.addEventListener("dragleave", event => this._onEncounterDropZoneLeave(event, card), captureOptions);
+        target.addEventListener("drop", event => void this._onEncounterPlayerDrop(event, card), captureOptions);
+      }
+    }
+
+    for (const zone of root.querySelectorAll?.(".looter-unassigned-dropzone") ?? []) {
+      const targets = [zone, ...zone.querySelectorAll("*")];
+      for (const target of targets) {
+        target.addEventListener("dragenter", event => this._onEncounterDropZoneOver(event, zone), captureOptions);
+        target.addEventListener("dragover", event => this._onEncounterDropZoneOver(event, zone), captureOptions);
+        target.addEventListener("dragleave", event => this._onEncounterDropZoneLeave(event, zone), captureOptions);
+        target.addEventListener("drop", event => void this._onEncounterDeleteDrop(event, zone), captureOptions);
+      }
+    }
+
+    doc?.addEventListener("mousedown", this._onEncounterDocumentMouseDown.bind(this), captureOptions);
+    doc?.addEventListener("dragstart", this._onEncounterDocumentDragStart.bind(this), captureOptions);
+    doc?.addEventListener("dragend", this._onEncounterDocumentDragEnd.bind(this), captureOptions);
+    doc?.addEventListener("dragenter", this._onEncounterDocumentDrag.bind(this), captureOptions);
+    doc?.addEventListener("dragover", this._onEncounterDocumentDrag.bind(this), captureOptions);
+    doc?.addEventListener("dragleave", this._onEncounterDocumentDragLeave.bind(this), captureOptions);
+    doc?.addEventListener("drop", this._onEncounterDocumentDrop.bind(this), captureOptions);
+
+    this._bodyListenersAbort = controller;
+  }
+
+  _onEncounterBodyClick(event) {
+    const target = getEventTargetElement(event);
+    if (!target) return;
+    if (target.closest("[data-action]")) return;
+
+    const row = target.closest(".looter-item-row[data-index]");
+    if (!row) return;
+
+    event.preventDefault();
+    void this._runLooterAction(
+      () => this._openItem(Number(row.dataset.index)),
+      "Encounter item preview failed",
+      "Looter couldn't open that loot item."
+    );
+  }
+
+  _setEncounterDropState(target, active) {
+    const zone = target?.closest?.(".looter-player-card, .looter-unassigned-dropzone") || target;
+    if (!zone) return;
+    zone.classList.toggle("is-drop-target", active);
+  }
+
+  _setActiveEncounterDropzone(zone) {
+    if (this._activeEncounterDropzone && this._activeEncounterDropzone !== zone) {
+      this._setEncounterDropState(this._activeEncounterDropzone, false);
+    }
+    this._activeEncounterDropzone = zone || null;
+    if (zone) this._setEncounterDropState(zone, true);
+  }
+
+  _clearEncounterDropTargets() {
+    this._setActiveEncounterDropzone(null);
+    const root = this.bodyElement ?? this.element;
+    for (const zone of root?.querySelectorAll?.(".looter-player-card.is-drop-target, .looter-unassigned-dropzone.is-drop-target") ?? []) {
+      zone.classList.remove("is-drop-target");
+    }
+  }
+
+  _findEncounterDropzoneByPoint(event) {
+    const dragEvent = event?.originalEvent ?? event;
+    const x = Number(dragEvent?.clientX);
+    const y = Number(dragEvent?.clientY);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+
+    const doc = (this.bodyElement ?? this.element)?.ownerDocument;
+    for (const node of doc?.elementsFromPoint?.(x, y) ?? []) {
+      const zone = node?.closest?.(".looter-player-card, .looter-unassigned-dropzone");
+      if (zone) return zone;
+    }
+
+    return this._findDropzoneByPoint(".looter-player-card, .looter-unassigned-dropzone", event);
+  }
+
+  _getDraggedEncounterItemIndex(event) {
+    const dragEvent = event?.originalEvent ?? event;
+    const dataTransfer = dragEvent?.dataTransfer;
+    const raw = String(
+      dataTransfer?.getData("application/x-looter-item-index")
+      || dataTransfer?.getData("text/plain")
+      || ""
+    ).trim();
+    if (!raw) {
+      const rowIndex = Number(this._encounterDraggedItemRow?.dataset?.index);
+      if (Number.isFinite(rowIndex)) return rowIndex;
+      return Number.isFinite(this._encounterDraggedItemIndex) ? this._encounterDraggedItemIndex : null;
+    }
+    const index = Number(raw);
+    if (Number.isFinite(index)) return index;
+    const rowIndex = Number(this._encounterDraggedItemRow?.dataset?.index);
+    if (Number.isFinite(rowIndex)) return rowIndex;
+    return Number.isFinite(this._encounterDraggedItemIndex) ? this._encounterDraggedItemIndex : null;
+  }
+
+  _onEncounterRowPointerDown(event) {
+    const target = getEventTargetElement(event);
+    if (!target || target.closest("[data-action], input, select, textarea, button, a, label")) return;
+
+    const row = target.closest(".looter-item-row[data-index]");
+    const index = Number(row?.dataset.index);
+    if (!row || !Number.isFinite(index)) return;
+
+    this._encounterDraggedItemIndex = index;
+    this._encounterDraggedItemRow = row;
+  }
+
+  _encounterAppContains(node) {
+    if (!node) return false;
+    const containers = [this.bodyElement, this.element, this.window?.content]
+      .filter(container => typeof container?.contains === "function");
+    return containers.some(container => container.contains(node));
+  }
+
+  _findEncounterLootRowFromEvent(event) {
+    const target = getEventTargetElement(event);
+    const targetMatch = target?.closest?.(".looter-item-row[data-index]");
+    if (this._encounterAppContains(targetMatch)) return targetMatch;
+
+    const path = typeof event?.composedPath === "function" ? event.composedPath() : [];
+    for (const node of path) {
+      if (node?.matches?.(".looter-item-row[data-index]") && this._encounterAppContains(node)) return node;
+      const row = node?.closest?.(".looter-item-row[data-index]");
+      if (this._encounterAppContains(row)) return row;
+    }
+
+    return null;
+  }
+
+  _onEncounterDocumentMouseDown(event) {
+    if (event.button !== 0) return;
+    const row = this._findEncounterLootRowFromEvent(event);
+    if (!row) return;
+    this._onEncounterRowPointerDown(event);
+  }
+
+  _onEncounterDocumentDragStart(event) {
+    const row = this._findEncounterLootRowFromEvent(event);
+    if (!row) return;
+    this._onEncounterItemDragStart(event, row);
+  }
+
+  _onEncounterDocumentDragEnd(event) {
+    const row = this._findEncounterLootRowFromEvent(event) ?? this._encounterDraggedItemRow;
+    if (!row) return;
+    this._onEncounterItemDragEnd(row);
+  }
+
+  _onEncounterItemDragStart(event, row = event.currentTarget) {
+    const dragEvent = event?.originalEvent ?? event;
+    const index = Number(row?.dataset.index);
+    if (!Number.isFinite(index)) return;
+
+    this._encounterDraggedItemIndex = index;
+    this._encounterDraggedItemRow = row ?? null;
+    row?.classList?.add("is-dragging");
+    dragEvent.dataTransfer?.setData("application/x-looter-item-index", String(index));
+    dragEvent.dataTransfer?.setData("text/plain", String(index));
+    if (dragEvent.dataTransfer) dragEvent.dataTransfer.effectAllowed = "move";
+  }
+
+  _onEncounterItemDragEnd(row = this._encounterDraggedItemRow) {
+    this._clearEncounterDropTargets();
+    row?.classList?.remove("is-dragging");
+  }
+
+  _onEncounterDocumentDrag(event) {
+    const zone = this._findEncounterDropzoneByPoint(event);
+    if (!zone) {
+      this._setActiveEncounterDropzone(null);
+      return;
+    }
+
+    this._setActiveEncounterDropzone(zone);
+    this._onEncounterDropZoneOver(event, zone);
+  }
+
+  _onEncounterDocumentDragLeave(event) {
+    const zone = this._findEncounterDropzoneByPoint(event);
+    if (zone) return;
+    this._setActiveEncounterDropzone(null);
+  }
+
+  _onEncounterDocumentDrop(event) {
+    const zone = this._findEncounterDropzoneByPoint(event);
+    this._setActiveEncounterDropzone(null);
+    if (!zone) return;
+
+    if (zone.matches(".looter-player-card")) {
+      void this._onEncounterPlayerDrop(event, zone);
+      return;
+    }
+
+    if (zone.matches(".looter-unassigned-dropzone")) {
+      void this._onEncounterDeleteDrop(event, zone);
+    }
+  }
+
+  _onEncounterDropZoneOver(event, zone = event.currentTarget) {
+    event.preventDefault();
+    event.stopPropagation();
+    this._setEncounterDropState(zone, true);
+    this._setActiveEncounterDropzone(zone);
+    const dragEvent = event?.originalEvent ?? event;
+    if (dragEvent.dataTransfer) dragEvent.dataTransfer.dropEffect = "move";
+  }
+
+  _onEncounterDropZoneLeave(event, zone = event.currentTarget) {
+    const next = event.relatedTarget;
+    if (next && zone?.contains?.(next)) return;
+    this._setEncounterDropState(zone, false);
+    if (this._activeEncounterDropzone === zone) this._activeEncounterDropzone = null;
+  }
+
+  async _onEncounterPlayerDrop(event, zone = event.currentTarget) {
+    event.preventDefault();
+    event.stopPropagation();
+    this._setEncounterDropState(zone, false);
+    if (this._activeEncounterDropzone === zone) this._activeEncounterDropzone = null;
+
+    const index = this._getDraggedEncounterItemIndex(event);
+    const actorId = String(zone?.dataset.actorId || "");
+    if (!Number.isFinite(index) || !this.rewardsState.items[index] || !actorId) return;
+
+    this.rewardsState.items[index].assignee = actorId;
+    this._encounterDraggedItemRow = null;
+    this._encounterDraggedItemIndex = null;
+    await this._renderPreservingScroll();
+  }
+
+  async _onEncounterDeleteDrop(event, zone = event.currentTarget) {
+    event.preventDefault();
+    event.stopPropagation();
+    this._setEncounterDropState(zone, false);
+    if (this._activeEncounterDropzone === zone) this._activeEncounterDropzone = null;
+
+    const index = this._getDraggedEncounterItemIndex(event);
+    if (!Number.isFinite(index) || !this.rewardsState.items[index]) return;
+
+    this.rewardsState.items.splice(index, 1);
+    this._encounterDraggedItemRow = null;
+    this._encounterDraggedItemIndex = null;
+    await this._renderPreservingScroll();
+  }
+
+  async _applyRewards() {
+    const root = this.bodyElement;
     if (!root) return;
-    const enemyList = root.querySelector(".looter-enemy-list");
-    const playerList = root.querySelector(".looter-player-list");
-    const lootList = root.querySelector(".looter-loot-scroll");
-    if (enemyList) enemyList.scrollTop = clampNumber(positions?.enemies, 0);
-    if (playerList) playerList.scrollTop = clampNumber(positions?.players, 0);
-    if (lootList) lootList.scrollTop = clampNumber(positions?.loot, 0);
+
+    await this._syncStateFromForm(root);
+    await grantRewards(this._payloadForApply());
+    ui.notifications.info("Looter rewards applied.");
+    await this.render({ force: true });
   }
 
-  _ensureEncounterCardControls(root) {
+  async _sendSummaryToChat() {
+    const root = this.bodyElement;
     if (!root) return;
 
-    const displayEnemies = stackEnemiesForDisplay(this.state.enemies);
-    root.querySelectorAll(".looter-enemy-card").forEach((card, index) => {
-      let button = card.querySelector(".looter-reroll-enemy");
-      if (!button) {
-        button = document.createElement("button");
-        button.type = "button";
-        button.className = "looter-card-reroll looter-reroll-enemy";
-        button.title = "Reroll this enemy's rewards";
-        button.setAttribute("aria-label", "Reroll this enemy's rewards");
-        button.innerHTML = `<i class="fas fa-rotate-right"></i>`;
-        card.append(button);
-      }
-      button.dataset.indexes = displayEnemies[index]?.memberIndexCsv || "";
+    await this._syncStateFromForm(root);
+    const payload = this._payloadForApply();
+    payload.items = payload.items.map(item => ({ ...item, assigneeName: this.rewardsState.players.find(p => p.actorId === item.assignee)?.name || "" }));
+    await ChatMessage.create({
+      content: await rewardsSummaryChatHTML(payload),
+      speaker: ChatMessage.getSpeaker({ alias: "Looter" })
     });
-
-    const unassignedItems = this.state.items
-      .map((item, index) => ({ item, index }))
-      .filter(({ item }) => !item.assignee);
-
-    root.querySelectorAll(".looter-item-row").forEach((row, index) => {
-      let button = row.querySelector(".looter-reroll-item");
-      if (!button) {
-        button = document.createElement("button");
-        button.type = "button";
-        button.className = "looter-card-reroll looter-reroll-item";
-        button.title = "Reroll this loot item";
-        button.setAttribute("aria-label", "Reroll this loot item");
-        button.innerHTML = `<i class="fas fa-rotate-right"></i>`;
-        row.append(button);
-      }
-      button.dataset.index = String(unassignedItems[index]?.index ?? "");
-    });
+    ui.notifications.info("Looter summary sent to chat.");
   }
 
-  activateListeners(html) {
-    super.activateListeners(html);
-    this._ensureEncounterCardControls(html[0]);
-
-    html.find(".looter-reroll").on("click", async ev => {
-      ev.preventDefault();
-      await this._reroll();
-    });
-
-    html.find(".looter-apply").on("click", async ev => {
-      ev.preventDefault();
-      await this._syncStateFromForm(html[0]);
-      await grantRewards(this._payloadForApply());
-      ui.notifications.info("Looter rewards applied.");
-      this.render(false);
-    });
-
-    html.find(".looter-chat").on("click", async ev => {
-      ev.preventDefault();
-      await this._syncStateFromForm(html[0]);
-      const payload = this._payloadForApply();
-      payload.items = payload.items.map(item => ({ ...item, assigneeName: this.state.players.find(p => p.actorId === item.assignee)?.name || "" }));
-      await ChatMessage.create({
-        content: await rewardsSummaryChatHTML(payload),
-        speaker: ChatMessage.getSpeaker({ alias: "Looter" })
-      });
-      ui.notifications.info("Looter summary sent to chat.");
-    });
-
-    html.find(".looter-reroll-enemy").on("click", async ev => {
-      ev.preventDefault();
-      ev.stopPropagation();
-      await this._rerollEnemyRewards(ev.currentTarget.dataset.indexes || "");
-    });
-
-    html.find(".looter-reroll-item").on("click", async ev => {
-      ev.preventDefault();
-      ev.stopPropagation();
-      const idx = Number(ev.currentTarget.dataset.index);
-      if (!Number.isFinite(idx)) return;
-      await this._rerollLootItem(idx);
-    });
-
-    html.find(".looter-unassign-pill").on("click", ev => {
-      ev.preventDefault();
-      const idx = Number(ev.currentTarget.dataset.index);
-      if (!Number.isFinite(idx) || !this.state.items[idx]) return;
-      this.state.items[idx].assignee = "";
-      this._renderPreservingScroll();
-    });
-
-    html.find(".looter-item-row").attr("draggable", true)
-      .on("dragstart", ev => {
-        const idx = Number(ev.currentTarget.dataset.index);
-        if (!Number.isFinite(idx)) return;
-        ev.originalEvent.dataTransfer?.setData("text/plain", String(idx));
-        ev.originalEvent.dataTransfer.effectAllowed = "move";
-      })
-      .on("click", ev => {
-        ev.preventDefault();
-        const idx = Number(ev.currentTarget.dataset.index);
-        if (!Number.isFinite(idx)) return;
-        this._openItem(idx);
-      });
-
-    html.find(".looter-player-card").on("dragover", ev => {
-      ev.preventDefault();
-      ev.currentTarget.classList.add("is-drop-target");
-      if (ev.originalEvent.dataTransfer) ev.originalEvent.dataTransfer.dropEffect = "move";
-    }).on("dragleave", ev => {
-      ev.currentTarget.classList.remove("is-drop-target");
-    }).on("drop", ev => {
-      ev.preventDefault();
-      ev.currentTarget.classList.remove("is-drop-target");
-      const idx = Number(ev.originalEvent.dataTransfer?.getData("text/plain"));
-      const actorId = ev.currentTarget.dataset.actorId || "";
-      if (!Number.isFinite(idx) || !this.state.items[idx]) return;
-      this.state.items[idx].assignee = actorId;
-      this._renderPreservingScroll();
-    });
-
-    html.find(".looter-unassigned-dropzone").on("dragover", ev => {
-      ev.preventDefault();
-      ev.currentTarget.classList.add("is-drop-target");
-      if (ev.originalEvent.dataTransfer) ev.originalEvent.dataTransfer.dropEffect = "move";
-    }).on("dragleave", ev => {
-      ev.currentTarget.classList.remove("is-drop-target");
-    }).on("drop", ev => {
-      ev.preventDefault();
-      ev.currentTarget.classList.remove("is-drop-target");
-      const idx = Number(ev.originalEvent.dataTransfer?.getData("text/plain"));
-      if (!Number.isFinite(idx) || !this.state.items[idx]) return;
-      const item = this.state.items[idx];
-      // Only remove items that are currently unassigned (i.e., visible in the loot column)
-      if (!item.assignee) {
-        this.state.items.splice(idx, 1);
-        this._renderPreservingScroll();
-      }
-    });
+  async _unassignItem(index) {
+    if (!Number.isFinite(index) || !this.rewardsState.items[index]) return;
+    this.rewardsState.items[index].assignee = "";
+    await this._renderPreservingScroll();
   }
 
   async _syncStateFromForm(root) {
-    this.state.players.forEach((player, idx) => {
+    this.rewardsState.players.forEach((player, idx) => {
       const checkbox = root.querySelector(`[name="players.${idx}.enabled"]`);
       player.enabled = checkbox ? checkbox.checked : true;
     });
 
-    this.state.xp = clampNumber(root.querySelector('[name="xp"]')?.value, this.state.xp);
+    this.rewardsState.xp = clampNumber(root.querySelector('[name="xp"]')?.value, this.rewardsState.xp);
     for (const denom of ["pp", "gp", "ep", "sp", "cp"]) {
-      this.state.currency[denom] = clampNumber(root.querySelector(`[name="currency.${denom}"]`)?.value, 0);
+      this.rewardsState.currency[denom] = clampNumber(root.querySelector(`[name="currency.${denom}"]`)?.value, 0);
     }
 
   }
@@ -1563,12 +2608,12 @@ class LooterEncounterApp extends FormApplication {
 
   _rebuildCurrencyFromEnemyRewards() {
     const totals = zeroCurrencyTotals();
-    for (const enemy of this.state.enemies) addCurrencyTotals(totals, enemy?.rewards?.currency);
-    this.state.currency = totals;
+    for (const enemy of this.rewardsState.enemies) addCurrencyTotals(totals, enemy?.rewards?.currency);
+    this.rewardsState.currency = totals;
   }
 
   _replaceEnemyRewardItem(itemId, replacement) {
-    for (const enemy of this.state.enemies) {
+    for (const enemy of this.rewardsState.enemies) {
       const rewardItems = Array.isArray(enemy?.rewards?.items) ? enemy.rewards.items : [];
       const itemIndex = rewardItems.findIndex(item => item.id === itemId);
       if (itemIndex < 0) continue;
@@ -1578,31 +2623,30 @@ class LooterEncounterApp extends FormApplication {
   }
 
   async _rerollEnemyRewards(indexesValue) {
-    const root = this.form ?? this.element?.[0];
+    const root = this.bodyElement;
     if (!root) return;
 
     await this._syncStateFromForm(root);
-    const scrollPositions = this._captureScrollPositions(root);
     const indexes = [...new Set(this._parseEnemyIndexes(indexesValue))];
     if (!indexes.length) return;
 
     for (const index of indexes) {
-      const enemy = this.state.enemies[index];
+      const enemy = this.rewardsState.enemies[index];
       if (!enemy) continue;
 
       const oldRewardItems = Array.isArray(enemy.rewards?.items)
         ? enemy.rewards.items.map(item => {
-          const liveItem = this.state.items.find(stateItem => stateItem.id === item.id);
+          const liveItem = this.rewardsState.items.find(stateItem => stateItem.id === item.id);
           return clone(liveItem || item);
         })
         : [];
       const oldIds = new Set(oldRewardItems.map(item => item.id));
       const oldIndexes = oldRewardItems
-        .map(item => this.state.items.findIndex(stateItem => stateItem.id === item.id))
+        .map(item => this.rewardsState.items.findIndex(stateItem => stateItem.id === item.id))
         .filter(i => i >= 0)
         .sort((a, b) => a - b);
-      const insertAt = oldIndexes[0] ?? this.state.items.length;
-      const keptItems = this.state.items.filter(item => !oldIds.has(item.id));
+      const insertAt = oldIndexes[0] ?? this.rewardsState.items.length;
+      const keptItems = this.rewardsState.items.filter(item => !oldIds.has(item.id));
 
       const freshRewards = await rollFromTreasurePlan({
         cr: enemy.cr,
@@ -1616,7 +2660,7 @@ class LooterEncounterApp extends FormApplication {
       }));
 
       keptItems.splice(insertAt, 0, ...freshItems);
-      this.state.items = keptItems;
+      this.rewardsState.items = keptItems;
       enemy.rewards = {
         currency: clone(freshRewards.currency),
         items: freshItems.map(item => clone(item))
@@ -1624,20 +2668,19 @@ class LooterEncounterApp extends FormApplication {
     }
 
     this._rebuildCurrencyFromEnemyRewards();
-    await this._renderPreservingScroll(scrollPositions);
+    await this._renderPreservingScroll();
 
-    const firstEnemy = this.state.enemies[indexes[0]];
+    const firstEnemy = this.rewardsState.enemies[indexes[0]];
     const label = firstEnemy ? (indexes.length > 1 ? `${firstEnemy.name} x${indexes.length}` : firstEnemy.name) : "enemy rewards";
     ui.notifications.info(`Looter rerolled ${label}.`);
   }
 
   async _rerollLootItem(index) {
-    const root = this.form ?? this.element?.[0];
-    const item = this.state.items[index];
+    const root = this.bodyElement;
+    const item = this.rewardsState.items[index];
     if (!root || !item) return;
 
     await this._syncStateFromForm(root);
-    const scrollPositions = this._captureScrollPositions(root);
     const profile = findTreasureProfile(item.sourceType, item.tier) || findTreasureProfile("Any", item.tier);
     if (!profile?.itemTable) {
       ui.notifications.warn(`No RollTable is linked for ${item.sourceType} ${item.tier}.`);
@@ -1656,9 +2699,9 @@ class LooterEncounterApp extends FormApplication {
       id: item.id,
       assignee: item.assignee || ""
     };
-    this.state.items[index] = replacement;
+    this.rewardsState.items[index] = replacement;
     this._replaceEnemyRewardItem(item.id, replacement);
-    await this._renderPreservingScroll(scrollPositions);
+    await this._renderPreservingScroll();
     ui.notifications.info(`Looter rerolled ${item.name}.`);
   }
 
@@ -1684,25 +2727,25 @@ class LooterEncounterApp extends FormApplication {
     };
 
     const fresh = await buildEncounterSnapshot(fakeCombat);
-    this.state.enemies = clone(fresh.enemies);
-    this.state.xp = fresh.totals.xp;
-    this.state.currency = clone(fresh.totals.currency);
-    this.state.items = fresh.totals.items.map(i => ({ ...i, assignee: "" }));
+    this.rewardsState.enemies = clone(fresh.enemies);
+    this.rewardsState.xp = fresh.totals.xp;
+    this.rewardsState.currency = clone(fresh.totals.currency);
+    this.rewardsState.items = fresh.totals.items.map(i => ({ ...i, assignee: "" }));
     await this._renderPreservingScroll();
   }
 
   _payloadForApply() {
     return {
-      players: clone(this.state.players),
-      xp: this.state.xp,
-      currency: clone(this.state.currency),
-      items: clone(this.state.items)
+      players: clone(this.rewardsState.players),
+      xp: this.rewardsState.xp,
+      currency: clone(this.rewardsState.currency),
+      items: clone(this.rewardsState.items)
     };
   }
 
   async _openItem(idx) {
-    if (!Number.isFinite(idx) || !this.state.items[idx]) return;
-    const item = this.state.items[idx];
+    if (!Number.isFinite(idx) || !this.rewardsState.items[idx]) return;
+    const item = this.rewardsState.items[idx];
 
     try {
       if (item.sourceUuid) {
@@ -1735,25 +2778,48 @@ class LooterEncounterApp extends FormApplication {
     }).render(true);
   }
 
+  async _preClose(options) {
+    this._bodyListenersAbort?.abort();
+    this._bodyListenersAbort = null;
+    this._activeEncounterDropzone = null;
+    this._encounterDraggedItemRow = null;
+    this._encounterDraggedItemIndex = null;
+    return super._preClose(options);
+  }
+}
 
-  async close(options) {
-    return super.close(options);
+async function focusOrRenderLooterApp(AppClass) {
+  const instances = Array.from(AppClass.instances());
+  const existing = instances.find(app => app.rendered && app.element?.isConnected);
+
+  if (existing) {
+    if (existing.minimized) await existing.maximize();
+    await existing.render({ force: true });
+    existing.bringToFront();
+    return existing;
   }
 
-  async _updateObject(_event, _formData) {}
+  for (const stale of instances) {
+    await stale.close();
+  }
+
+  const app = new AppClass();
+  await app.render({ force: true });
+  app.bringToFront();
+  return app;
 }
 
 function openMonsterTableApp() {
-  new LooterMonsterTableApp().render(true);
+  void focusOrRenderLooterApp(LooterMonsterTableApp);
 }
 
 function openTreasureProfilesApp() {
-  new LooterTreasureProfilesApp().render(true);
+  void focusOrRenderLooterApp(LooterTreasureProfilesApp);
 }
 
 function openEncounterApp(snapshot) {
   if (!snapshot) return;
-  const existing = Object.values(ui.windows || {}).find(w => w instanceof LooterEncounterApp);
+  const existing = Array.from(LooterEncounterApp.instances()).find(app => app.rendered);
   if (existing) existing.close();
   new LooterEncounterApp(snapshot).render(true);
 }
@@ -1775,66 +2841,38 @@ function queueEncounterAppOpen(combatId, snapshot, delay = 25) {
 }
 
 Hooks.once("init", () => {
-  game.settings.register(LOOTER_ID, "monsterTable", {
-    name: "Monster Table",
-    hint: "Internal monster lookup table for Looter.",
-    scope: "world",
-    config: false,
-    type: Array,
-    default: []
-  });
+  const liveNamespace = getLooterModule()?.id || MODULE_FOLDER || LOOTER_ID;
+  SETTINGS_NAMESPACE = liveNamespace;
 
-  game.settings.register(LOOTER_ID, "treasureProfiles", {
-    name: "Treasure Profiles",
-    hint: "Currency formulas and linked item tables for each treasure type and CR tier.",
-    scope: "world",
-    config: false,
-    type: Array,
-    default: []
-  });
+  if (SETTINGS_NAMESPACE !== LOOTER_ID) {
+    console.warn(
+      `${LOOTER_ID} | Registering settings under live package id "${SETTINGS_NAMESPACE}". ` +
+      `Rename the module folder to "${LOOTER_ID}" to keep package ids and settings namespaces aligned.`
+    );
+    registerLooterSettings(LOOTER_ID, { forceHidden: true });
+  }
 
-  game.settings.register(LOOTER_ID, "useXp", {
-    name: "Award XP",
-    hint: "Turn this off for milestone campaigns.",
-    scope: "world",
-    config: true,
-    type: Boolean,
-    default: true
-  });
-
-  game.settings.register(LOOTER_ID, "theme", {
-    name: "Window Theme",
-    hint: "Color theme for Looter windows.",
-    scope: "client",
-    config: true,
-    type: String,
-    choices: THEME_CHOICES,
-    default: "violet"
-  });
-
-  game.settings.registerMenu(LOOTER_ID, "monsterTableMenu", {
-    name: "Open Monster Registry",
-    label: "Monster Registry",
-    hint: "Open the Looter monster registry.",
-    icon: "fas fa-dragon",
-    type: LooterMonsterTableApp,
-    restricted: true
-  });
-
-  game.settings.registerMenu(LOOTER_ID, "treasureProfilesMenu", {
-    name: "Open Treasure Profiles",
-    label: "Treasure Profiles",
-    hint: "Open the Looter treasure profiles manager.",
-    icon: "fas fa-coins",
-    type: LooterTreasureProfilesApp,
-    restricted: true
-  });
+  registerLooterSettings(SETTINGS_NAMESPACE, { includeMenus: true });
+  void (async () => {
+    await migrateLegacySettingsNamespace(LOOTER_ID, SETTINGS_NAMESPACE);
+    await normalizeStructuredSettings(SETTINGS_NAMESPACE);
+    await syncSettingsNamespace(SETTINGS_NAMESPACE, LOOTER_ID);
+    await normalizeStructuredSettings(LOOTER_ID);
+  })();
 });
 
 Hooks.once("ready", async () => {
   await ensureWorldTables();
   await ensureTreasureProfiles();
-  game.modules.get(LOOTER_ID).api = {
+  const looterModule = getLooterModule();
+  if (!looterModule) {
+    console.warn(
+      `${LOOTER_ID} | Could not resolve this package in game.modules, so the public API was not registered.`
+    );
+    return;
+  }
+
+  looterModule.api = {
     openMonsterTableApp,
     openTreasureProfilesApp,
     buildEncounterSnapshot,

--- a/styles/looter.css
+++ b/styles/looter.css
@@ -444,10 +444,21 @@
 .looter-item-row {
   cursor: grab;
   justify-content: flex-start;
+  user-select: none;
+}
+
+.looter-item-row .looter-item-meta,
+.looter-item-row .looter-item-meta * {
+  pointer-events: none;
 }
 
 .looter-item-row:active {
   cursor: grabbing;
+}
+
+.looter-item-row.is-dragging {
+  opacity: 0.72;
+  box-shadow: 0 0 0 1px var(--looter-accent) inset;
 }
 
 .looter-item-controls {
@@ -542,14 +553,34 @@
   gap: 0.35rem;
   padding: 0.2rem;
   margin: -0.2rem;
+  min-height: 40px;
   border: 1px dashed transparent;
   border-radius: 10px;
+  cursor: copy;
   transition: border-color 140ms ease, background 140ms ease;
 }
 
 .looter-table-dropzone .looter-table-display {
   flex: 1 1 auto;
-  cursor: copy;
+  min-width: 0;
+  min-height: 38px;
+  display: flex;
+  align-items: center;
+  padding: 0 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(255,255,255,0.14);
+  background: rgba(2,6,23,0.48);
+  color: inherit;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: inherit;
+  pointer-events: none;
+  user-select: none;
+}
+
+.looter-table-dropzone .looter-table-display.is-placeholder {
+  opacity: 0.7;
 }
 
 .looter-table-dropzone.is-drop-target {

--- a/templates/encounter-rewards.html
+++ b/templates/encounter-rewards.html
@@ -1,4 +1,4 @@
-<form class="looter-shell looter-encounter-shell">
+<div class="looter-shell looter-encounter-shell">
   <header class="looter-toolbar">
     <div>
       <h2>Looter Rewards</h2>
@@ -6,9 +6,9 @@
       <p>Clicking "Send Summary to Chat" after applying rewards will publish what players was assigned each loot item.</p>
     </div>
     <div class="looter-toolbar-actions">
-      <button type="button" class="looter-reroll"><i class="fas fa-dice"></i> Reroll Rewards</button>
-      <button type="button" class="looter-chat"><i class="fas fa-comments"></i> Send Summary to Chat</button>
-      <button type="button" class="looter-apply primary"><i class="fas fa-gift"></i> Apply Rewards</button>
+      <button type="button" class="looter-reroll" data-action="rerollRewards"><i class="fas fa-dice"></i> Reroll Rewards</button>
+      <button type="button" class="looter-chat" data-action="sendSummary"><i class="fas fa-comments"></i> Send Summary to Chat</button>
+      <button type="button" class="looter-apply primary" data-action="applyRewards"><i class="fas fa-gift"></i> Apply Rewards</button>
     </div>
   </header>
 
@@ -18,7 +18,7 @@
       <div class="looter-enemy-list">
         {{#each enemies as |enemy|}}
         <article class="looter-enemy-card">
-          <button type="button" class="looter-card-reroll looter-reroll-enemy" data-indexes="{{enemy.memberIndexCsv}}" title="Reroll this enemy's rewards" aria-label="Reroll this enemy's rewards">
+          <button type="button" class="looter-card-reroll looter-reroll-enemy" data-action="rerollEnemy" data-indexes="{{enemy.memberIndexCsv}}" title="Reroll this enemy's rewards" aria-label="Reroll this enemy's rewards">
             <i class="fas fa-rotate-right"></i>
           </button>
           <img src="{{enemy.img}}" alt="{{enemy.name}}">
@@ -47,7 +47,7 @@
             <div class="looter-assigned-list">
               {{#if player.assignedItems.length}}
                 {{#each player.assignedItems as |item|}}
-                <button type="button" class="looter-assigned-pill looter-unassign-pill" data-index="{{item.index}}" title="Remove and return to loot">
+                <button type="button" class="looter-assigned-pill looter-unassign-pill" data-action="unassignItem" data-index="{{item.index}}" title="Remove and return to loot">
                   <span>{{item.name}}</span>
                   <i class="fas fa-xmark"></i>
                 </button>
@@ -86,11 +86,11 @@
         {{#if items.length}}
           {{#each items as |item|}}
           <div class="looter-item-row" data-index="{{item.index}}" draggable="true">
-            <button type="button" class="looter-card-reroll looter-reroll-item" data-index="{{item.index}}" title="Reroll this loot item" aria-label="Reroll this loot item">
+            <button type="button" class="looter-card-reroll looter-reroll-item" data-action="rerollItem" data-index="{{item.index}}" title="Reroll this loot item" aria-label="Reroll this loot item">
               <i class="fas fa-rotate-right"></i>
             </button>
             <div class="looter-item-meta">
-              <img src="{{item.img}}" alt="{{item.name}}">
+              <img src="{{item.img}}" alt="{{item.name}}" draggable="false">
               <div>
                 <strong>{{item.name}}</strong>
                 <p class="looter-muted">{{item.sourceType}} {{item.tier}}</p>
@@ -105,4 +105,4 @@
       </div>
     </div>
   </section>
-</form>
+</div>

--- a/templates/monster-table.html
+++ b/templates/monster-table.html
@@ -1,12 +1,12 @@
-<form class="looter-shell looter-manager-shell">
+<div class="looter-shell looter-manager-shell">
   <header class="looter-toolbar">
     <div>
       <h2>Monster Registry</h2>
       <p>Manage the monster lookup table that Looter uses after combat.</p>
     </div>
     <div class="looter-toolbar-actions">
-      <button type="button" class="looter-open-profiles"><i class="fas fa-coins"></i> Treasure Profiles</button>
-      <button type="button" class="looter-save primary"><i class="fas fa-save"></i> Save</button>
+      <button type="button" class="looter-open-profiles" data-action="openProfiles"><i class="fas fa-coins"></i> Treasure Profiles</button>
+      <button type="button" class="looter-save primary" data-action="saveRows"><i class="fas fa-save"></i> Save</button>
     </div>
   </header>
 
@@ -16,7 +16,7 @@
         <h3>Monster Table</h3>
         <p class="looter-muted">Looter searches defeated enemy names against this table.</p>
       </div>
-      <button type="button" class="looter-add-row"><i class="fas fa-plus"></i> Add Monster</button>
+      <button type="button" class="looter-add-row" data-action="addRow"><i class="fas fa-plus"></i> Add Monster</button>
     </div>
 
     <div class="looter-import-dropzone" data-import-dropzone>
@@ -29,10 +29,10 @@
         <thead>
           <tr>
             <th>
-              <button type="button" class="looter-sort-monsters" data-field="name">Name {{monsterSort.nameLabel}}</button>
+              <button type="button" class="looter-sort-monsters" data-action="sortRows" data-field="name">Name {{monsterSort.nameLabel}}</button>
             </th>
             <th>
-              <button type="button" class="looter-sort-monsters" data-field="cr">CR {{monsterSort.crLabel}}</button>
+              <button type="button" class="looter-sort-monsters" data-action="sortRows" data-field="cr">CR {{monsterSort.crLabel}}</button>
             </th>
             <th>XP</th>
             <th>Treasure Types</th>
@@ -47,7 +47,7 @@
             <td><input type="number" step="1" name="rows.{{i}}.xp" value="{{row.xp}}"></td>
             <td>
               <input type="hidden" name="rows.{{i}}.treasureTypes" value="{{row.treasureTypesValue}}">
-              <button type="button" class="looter-type-selector" data-index="{{i}}" aria-haspopup="dialog" aria-expanded="false">
+              <button type="button" class="looter-type-selector" data-action="toggleTreasureTypes" data-index="{{i}}" aria-haspopup="dialog" aria-expanded="false">
                 <span class="looter-type-selector-chips">
                   {{#if row.treasureTypes.length}}
                     {{#each row.treasureTypes as |type|}}<span class="looter-chip">{{type}}</span>{{/each}}
@@ -58,7 +58,7 @@
                 <i class="fas fa-chevron-down"></i>
               </button>
             </td>
-            <td><button type="button" class="looter-delete-row" data-index="{{i}}"><i class="fas fa-trash"></i></button></td>
+            <td><button type="button" class="looter-delete-row" data-action="deleteRow" data-index="{{i}}"><i class="fas fa-trash"></i></button></td>
           </tr>
           {{/each}}
         </tbody>
@@ -78,4 +78,4 @@
       <p>The "Treasure Types" drop down menu is auto-populated from the "Treasure Profiles Table" in the Treasure Profiles menu.</p>
     </div>
   </section>
-</form>
+</div>

--- a/templates/treasure-profiles.html
+++ b/templates/treasure-profiles.html
@@ -1,14 +1,14 @@
-<form class="looter-shell looter-manager-shell looter-profiles-shell">
+<div class="looter-shell looter-manager-shell looter-profiles-shell">
   <header class="looter-toolbar">
     <div>
       <h2>Treasure Profiles</h2>
       <p>Manage currency formulas and linked item tables for each treasure type and CR tier.</p>
     </div>
     <div class="looter-toolbar-actions">
-      <button type="button" class="looter-open-monsters"><i class="fas fa-dragon"></i> Monster Registry</button>
-      <button type="button" class="looter-seed-profiles"><i class="fas fa-coins"></i> Seed Profiles</button>
-      <button type="button" class="looter-seed-tables"><i class="fas fa-dice"></i> Seed Item Tables</button>
-      <button type="button" class="looter-save primary"><i class="fas fa-save"></i> Save</button>
+      <button type="button" class="looter-open-monsters" data-action="openMonsters"><i class="fas fa-dragon"></i> Monster Registry</button>
+      <button type="button" class="looter-seed-profiles" data-action="seedProfiles"><i class="fas fa-coins"></i> Seed Profiles</button>
+      <button type="button" class="looter-seed-tables" data-action="seedTables"><i class="fas fa-dice"></i> Seed Item Tables</button>
+      <button type="button" class="looter-save primary" data-action="saveProfiles"><i class="fas fa-save"></i> Save</button>
     </div>
   </header>
 
@@ -18,7 +18,7 @@
         <h3>Treasure Profiles Table</h3>
         <p class="looter-muted">Currency formulas live here. Item results come from the linked RollTable.</p>
       </div>
-      <button type="button" class="looter-add-profile"><i class="fas fa-plus"></i> Add Profile</button>
+      <button type="button" class="looter-add-profile" data-action="addProfile"><i class="fas fa-plus"></i> Add Profile</button>
     </div>
 
     <div class="looter-manager-table-wrap looter-profile-scroll-wrap">
@@ -54,14 +54,16 @@
             <td><input type="text" name="profiles.{{i}}.currency.sp" value="{{profile.currency.sp}}"></td>
             <td><input type="text" name="profiles.{{i}}.currency.cp" value="{{profile.currency.cp}}"></td>
             <td>
-              <div class="looter-table-dropzone" data-index="{{i}}">
+              <div class="looter-table-dropzone" data-index="{{i}}" title="{{profile.itemTableDisplay}}">
                 <input type="hidden" name="profiles.{{i}}.itemTable" value="{{profile.itemTable}}">
-                <input type="text" class="looter-table-display" value="{{profile.itemTableDisplay}}" placeholder="Drop RollTable here" title="{{profile.itemTableDisplay}}" readonly>
-                <button type="button" class="looter-clear-table" data-index="{{i}}" aria-label="Clear RollTable"><i class="fas fa-times"></i></button>
+                <div class="looter-table-display{{#unless profile.itemTableDisplay}} is-placeholder{{/unless}}">
+                  {{#if profile.itemTableDisplay}}{{profile.itemTableDisplay}}{{else}}Drop RollTable here{{/if}}
+                </div>
+                <button type="button" class="looter-clear-table" data-action="clearTable" data-index="{{i}}" aria-label="Clear RollTable"><i class="fas fa-times"></i></button>
               </div>
             </td>
             <td><input type="text" name="profiles.{{i}}.tableRolls" value="{{profile.tableRolls}}" placeholder="1"></td>
-            <td><button type="button" class="looter-delete-profile looter-delete-profile-white" data-index="{{i}}" aria-label="Delete profile"><i class="fas fa-trash"></i></button></td>
+            <td><button type="button" class="looter-delete-profile looter-delete-profile-white" data-action="deleteProfile" data-index="{{i}}" aria-label="Delete profile"><i class="fas fa-trash"></i></button></td>
           </tr>
           {{/each}}
         </tbody>
@@ -81,4 +83,4 @@
       <p>Profile types are what appear in the Monster Registry treasure-type selector. You can add as many as you like!</p>
     </div>
   </section>
-</form>
+</div>


### PR DESCRIPTION
- Updated Looter for **Foundry VTT v14** and **D&D 5e v5.3.0**
- Migrated the main Looter windows from the older app system to **ApplicationV2**
- Fixed module startup and settings registration issues caused by package id and folder name mismatches
- Repaired the **Monster Registry** so buttons, saving, window navigation, and actor drag-and-drop import work again
- Repaired **Treasure Profiles** so the treasure type controls, saving, cross-window navigation, and RollTable drag-and-drop work again
- Reworked the **Rewards** window to avoid V14 `state` conflicts and restored the **Reroll Rewards**, **Send Summary to Chat**, and **Apply Rewards** actions
- Fixed loot drag-and-drop in the Rewards screen so items can be assigned to players or dropped into the delete zone
- Cleaned up temporary drag-and-drop debugging after confirming the new V14 behavior was stable